### PR TITLE
Commit a test showing that <br> causes indentation (when it shouldn't)

### DIFF
--- a/src/djlint/formatter/indent_html.py
+++ b/src/djlint/formatter/indent_html.py
@@ -48,7 +48,7 @@ def indent_html(rawcode: str, config: Config) -> str:
                 fr"(<({slt_html})>)(.*?)(</(\2)>)", item, re.IGNORECASE | re.VERBOSE
             )
             or re.findall(
-                fr"(<({slt_html})[ ].+?>)(.*?)(</(\2)>)",
+                fr"(<({slt_html})\b.+?>)(.*?)(</(\2)>)",
                 item,
                 re.IGNORECASE | re.VERBOSE,
             )
@@ -58,12 +58,14 @@ def indent_html(rawcode: str, config: Config) -> str:
                 re.IGNORECASE | re.MULTILINE | re.VERBOSE,
             )
             or re.findall(
-                fr"(<({slt_html})[ ].*?/>)", item, flags=re.IGNORECASE | re.VERBOSE
+                fr"(<({slt_html})\b.*?/>)", item, flags=re.IGNORECASE | re.VERBOSE
             )
             or re.findall(
-                fr"(<({always_self_closing_html})[ ].*?/?>)",
+                re.compile(
+                    fr"(<({always_self_closing_html})\b.*?/?>)",
+                    re.IGNORECASE | re.VERBOSE,
+                ),
                 item,
-                flags=re.IGNORECASE | re.VERBOSE,
             )
         ) and is_block_raw is False:
             tmp = (indent * indent_level) + item + "\n"
@@ -94,9 +96,11 @@ def indent_html(rawcode: str, config: Config) -> str:
         # if indent, move right
         elif (
             re.search(
-                r"^(?:" + str(config.tag_indent) + r")",
+                re.compile(
+                    r"^(?:" + str(config.tag_indent) + r")",
+                    re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+                ),
                 item,
-                re.IGNORECASE | re.MULTILINE | re.VERBOSE,
             )
             and is_block_raw is False
         ):

--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -388,7 +388,7 @@ class Config:
                     """
             + self.indent_html_tags
             + """
-                )
+                )\\b
               )
         """
         )
@@ -404,7 +404,7 @@ class Config:
                     """
             + self.indent_html_tags
             + """
-                )
+                )\\b
               )
         """
         )
@@ -577,7 +577,8 @@ class Config:
             | with
         """
 
-        self.break_html_tags: str = r"""
+        self.break_html_tags: str = (
+            r"""
               html
             | head
             | body
@@ -619,11 +620,14 @@ class Config:
             | svg
             | h\d
             | button
-            | img
             | path
             | picture
             | script
             | style
             | details
             | summary
+            | """
+            + self.always_self_closing_html_tags
+            + """
         """
+        )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -5,7 +5,7 @@ run::
    pytest tests/test_html.py --cov=src/djlint --cov-branch \
           --cov-report xml:coverage.xml --cov-report term-missing
 
-   pytest tests/test_html.py::test_ignored_block --cov=src/djlint --cov-branch \
+   pytest tests/test_html.py::test_self_closing_tags --cov=src/djlint --cov-branch \
           --cov-report xml:coverage.xml --cov-report term-missing
 
 
@@ -362,28 +362,44 @@ def test_style_tag(runner: CliRunner, tmp_file: TextIO) -> None:
     assert output["exit_code"] == 0
 
 
-def test_self_closing_br_tag(runner: CliRunner, tmp_file: TextIO) -> None:
-    write_to_file(tmp_file.name, b"""<p><span>Hello</span> <br /> <span>World</span></p>""")
+def test_self_closing_tags(runner: CliRunner, tmp_file: TextIO) -> None:
+    write_to_file(
+        tmp_file.name,
+        b"""<p><span>Hello</span> <br /><input /><link /><img /><source /><meta /> <span>World</span></p>""",
+    )
     runner.invoke(djlint, [tmp_file.name, "--reformat"])
     assert (
         Path(tmp_file.name).read_text()
         == """<p>
     <span>Hello</span>
     <br />
+    <input />
+    <link />
+    <img />
+    <source />
+    <meta />
     <span>World</span>
 </p>
 """
     )
 
 
-def test_void_br_tag(runner: CliRunner, tmp_file: TextIO) -> None:
-    write_to_file(tmp_file.name, b"""<p><span>Hello</span> <br> <span>World</span></p>""")
+def test_void_self_closing_tag(runner: CliRunner, tmp_file: TextIO) -> None:
+    write_to_file(
+        tmp_file.name,
+        b"""<p><span>Hello</span> <br><input><link><img><source><meta> <span>World</span></p>""",
+    )
     runner.invoke(djlint, [tmp_file.name, "--reformat"])
     assert (
         Path(tmp_file.name).read_text()
         == """<p>
     <span>Hello</span>
     <br>
+    <input>
+    <link>
+    <img>
+    <source>
+    <meta>
     <span>World</span>
 </p>
 """


### PR DESCRIPTION
Here's two tests which shows that `<br>` causes indentations in the following lines but `<br />` doesn't. That's probably not intentional.

I tried fixing it but no luck.

Refs #92 