### PR TITLE
Sort pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,17 +28,17 @@ include = ["rules.yaml"]
 [tool.poetry.dependencies]
 python = "^3.8.0,<4.0"
 click = "^8.0.1"
-PyYAML = "^6.0"
 colorama = "^0.4.4"
-regex = "^2023.0.0"
-tqdm = "^4.62.2"
-tomli = { version = "^2.0.1", python = "<3.11" }
-pathspec = "^0.12.0"
-html-void-elements = "^0.1.0"
-html-tag-names = "^0.1.2"
-jsbeautifier = "^1.14.4"
 cssbeautifier = "^1.14.4"
+html-tag-names = "^0.1.2"
+html-void-elements = "^0.1.0"
+jsbeautifier = "^1.14.4"
 json5 = "^0.9.11"
+pathspec = "^0.12.0"
+PyYAML = "^6.0"
+regex = "^2023.0.0"
+tomli = { version = "^2.0.1", python = "<3.11" }
+tqdm = "^4.62.2"
 
 [tool.poetry.scripts]
 djlint = "djlint:main"


### PR DESCRIPTION
This makes it easier for linux distro maintainers to import the list of dependencies into their packaging formats, e.g. https://build.opensuse.org/package/show/home:jayvdb:py-new/python-djlint

I have left `python` entry at the top, as it isnt the same as the others