### PR TITLE
Fix: not detecting tabs as a valid seperation between tags.

### DIFF
--- a/src/djlint/formatter/condense.py
+++ b/src/djlint/formatter/condense.py
@@ -53,7 +53,7 @@ def clean_whitespace(html: str, config: Config) -> str:
     trailing_contents = r"\n \t"
 
     if config.preserve_blank_lines:
-        line_contents = r"([^\n]+?)"
+        line_contents = r"([^\n]*?)"
         trailing_contents = r" \t"
 
     if not config.preserve_leading_space:

--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -595,7 +595,7 @@ class Config:
               )
         """
 
-        self.break_before = r"(?<!\n[ ]*?)"
+        self.break_before = r"(?<!\n[ \t]*?)"
 
         # if lines are longer than x
         self.max_line_length = 120

--- a/tests/test_config/test_preserve_blank_lines.py
+++ b/tests/test_config/test_preserve_blank_lines.py
@@ -98,8 +98,13 @@ test_data = [
         ({"preserve_blank_lines": True}),
         id="whitespace test",
     ),
+    pytest.param(
+        ("<div>\n\t\n\t<div>\n\t\n\t</div>\n\t\n</div>"),
+        ("<div>\n\n    <div></div>\n\n</div>\n"),
+        ({"preserve_blank_lines": True}),
+        id="whitespace test with tabs",
+    ),
 ]
-
 
 @pytest.mark.parametrize(("source", "expected", "args"), test_data)
 def test_base(source, expected, args):


### PR DESCRIPTION
Resolves: #812 

- [x] Added tests for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->

It wasn't detecting tabs as a valid whitespace between HTML tags, causing it to transform:
`<div>\n\t<p></p>\n</div>`
into:
`<div>\n\t\n<p></p>\n</div>`

Notice that the transformed text has an extra new line after the tab character. Normally extra new lines are removed, but with `--preserve-blank-lines`, this extra new line persists.

Note:
 - `--preserve-blank-lines` and `--max-blank-lines` are incompatible with each other (I think this was true before my PR). Since `--max-blank-lines` preserves blank lines as well, it would make a lot of sense to combine the two options into one.