### PR TITLE
fix(H016): Allow attributes on <title>

### DIFF
--- a/src/djlint/rules.yaml
+++ b/src/djlint/rules.yaml
@@ -111,7 +111,9 @@
     message: Missing title tag in html.
     flags: re.DOTALL|re.I
     patterns:
-    - <html[^>]*?>(?:(?!<title>).)*</html>
+      # Title allow a list of global attributes.
+      # https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#list_of_global_attributes
+      - <html[^>]*?>(?:(?!<title(\s+(class|data-[\-\._0-9a-zA-Z:]+|dir|id|lang|translate)=\"[^"]*\")*>).)*</html>
 - rule:
     name: H017
     message: Void tags should be self closing.

--- a/tests/test_linter/test_linter.py
+++ b/tests/test_linter/test_linter.py
@@ -120,6 +120,16 @@ def test_H016(runner: CliRunner, tmp_file: TextIO) -> None:
     result = runner.invoke(djlint, [tmp_file.name])
     assert "H016" not in result.output
 
+    write_to_file(
+        tmp_file.name,
+        b"""\
+        <html>
+        <title id="title-reload-with-htmx" data-foo="bar">stuff</title>
+        </html>""",
+    )
+    result = runner.invoke(djlint, [tmp_file.name])
+    assert "H016" not in result.output
+
 
 def test_H017(runner: CliRunner, tmp_file: TextIO) -> None:
     write_to_file(tmp_file.name, b"<img this >")


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title:

> This element only includes the global attributes.

I picked those that seemed reasonable from
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#list_of_global_attributes

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
