### PR TITLE
fix: Cache some results of re.finditer

### DIFF
--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import itertools
 from typing import TYPE_CHECKING
 
@@ -10,6 +11,56 @@ import regex as re
 
 if TYPE_CHECKING:
     from .settings import Config
+
+child_of_unformatted_block_cache_: dict[str, list[tuple[int, int]]] = {}
+inside_ignored_block_cache_: dict[str, list[tuple[int, int]]] = {}
+
+
+def child_of_unformatted_block_cache(
+    config: Config, html: str
+) -> list[tuple[int, int]]:
+    key = hashlib.sha256(
+        (html + config.unformatted_blocks).encode("utf-8")
+    ).hexdigest()
+    if key in child_of_unformatted_block_cache_:
+        return child_of_unformatted_block_cache_[key]
+    matches = [
+        (x.start(0), x.end())
+        for x in re.finditer(
+            config.unformatted_blocks,
+            html,
+            flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+        )
+    ]
+    child_of_unformatted_block_cache_[key] = matches
+    return matches
+
+
+def inside_ignored_block_cache(
+    config: Config, html: str
+) -> list[tuple[int, int]]:
+    key = hashlib.sha256(
+        (html + config.unformatted_blocks).encode("utf-8")
+    ).hexdigest()
+    if key in inside_ignored_block_cache_:
+        return inside_ignored_block_cache_[key]
+    matches = [
+        (x.start(0), x.end())
+        for x in itertools.chain(
+            re.finditer(
+                config.ignored_blocks,
+                html,
+                flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+            ),
+            re.finditer(
+                config.ignored_inline_blocks,
+                html,
+                flags=re.IGNORECASE | re.VERBOSE,
+            ),
+        )
+    ]
+    inside_ignored_block_cache_[key] = matches
+    return matches
 
 
 def is_ignored_block_opening(config: Config, item: str) -> bool:
@@ -272,21 +323,11 @@ def inside_ignored_block(
     config: Config, html: str, match: re.Match[str]
 ) -> bool:
     """Do not add whitespace if the tag is in a non indent block."""
+    match_start = match.start()
+    match_end = match.end(0)
     return any(
-        ignored_match.start(0) <= match.start()
-        and match.end(0) <= ignored_match.end()
-        for ignored_match in itertools.chain(
-            re.finditer(
-                config.ignored_blocks,
-                html,
-                flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
-            ),
-            re.finditer(
-                config.ignored_inline_blocks,
-                html,
-                flags=re.IGNORECASE | re.VERBOSE,
-            ),
-        )
+        ignored_match[0] <= match_start and match_end <= ignored_match[1]
+        for ignored_match in inside_ignored_block_cache(config, html)
     )
 
 
@@ -294,14 +335,11 @@ def child_of_unformatted_block(
     config: Config, html: str, match: re.Match[str]
 ) -> bool:
     """Do not add whitespace if the tag is in a non indent block."""
+    match_start = match.start()
+    match_end = match.end(0)
     return any(
-        ignored_match.start(0) < match.start()
-        and match.end(0) <= ignored_match.end()
-        for ignored_match in re.finditer(
-            config.unformatted_blocks,
-            html,
-            flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
-        )
+        ignored_match[0] < match_start and match_end <= ignored_match[1]
+        for ignored_match in child_of_unformatted_block_cache(config, html)
     )
 
 

--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -337,10 +337,13 @@ def child_of_unformatted_block(
     """Do not add whitespace if the tag is in a non indent block."""
     match_start = match.start()
     match_end = match.end(0)
-    return any(
-        ignored_match[0] < match_start and match_end <= ignored_match[1]
-        for ignored_match in child_of_unformatted_block_cache(config, html)
-    )
+    ignored_matches = child_of_unformatted_block_cache(config, html)
+    if ignored_matches == []:
+        return False
+    for ignored_match in ignored_matches:
+        if ignored_match[0] < match_start and match_end <= ignored_match[1]:
+            return True
+    return False
 
 
 def child_of_ignored_block(


### PR DESCRIPTION
If a file is formatted, the code attempts to extract the ignored blocks or unformatted blocks several times from the same HTML string.

This commit adds a cache for the unique combination `sha256(html || config.REGEX)`. It stores the results as `[(begin,end)]`, as it seems like the accessing `.start()` or `.end()` is somewhat costly. (Same applies for the match that is given as argument)

# Testing

I used https://github.com/netbox-community/netbox for testing. In the `netbox` directory there are two subdirectories with templates: `templates` and `utilities`.

I cloned it twice:
```
/tmp/diff
  old/ <- For upstream master of djlint
  new/ <- For my changes
```

The outputs of `git diff HEAD~1` are identical

To test I used:
```
pip uninstall djlint -y; pip install djlint
cd /tmp/diff/old/netbox
time djlint templates/ utilities/ --reformat --format-css --format-js --lint > /tmp/diff/old.txt 2>&1
RESULT:
real          0m19.547s
user         1m16.303s
sys           0m0.134s
cd $MY_CODE
pip install -e .
cd /tmp/diff/new/netbox
time djlint templates/ utilities/ --reformat --format-css --format-js --lint > /tmp/diff/new.txt 2>&1
RESULT: (With first commit)
real         0m3.750s
user        0m13.885s
sys          0m0.120s
RESULT: (With both commits)
real         0m3.283s
user        0m12.713s
sys          0m0.117s
```

The diff is:
```diff
2c2
Reformatting and Linting 336/336 files ━━━━━━━━━━ 00:19    
---
Reformatting and Linting 336/336 files ━━━━━━━━━━ 00:03
```

# Pull Request Check List

Resolves: #XXX (Not applicable, as it's not user visible)

- [ ] Added **tests** for changed code. (Not applicable, as it doesn't add a feature and it's covered by existing tests
- [ ] Updated **documentation** for changed code. (Not sure if applicable)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->


