### PR TITLE
Performance Improvement 1 - Reduce number of pure calls.

### DIFF
--- a/djlint/formatter/indent.py
+++ b/djlint/formatter/indent.py
@@ -88,19 +88,22 @@ def indent_html(rawcode: str, config: Config) -> str:
     ignored_level = 0
 
     for item in rawcode_flat_list:
+        is_safe_closing_tag_ = is_safe_closing_tag(config, item)
+        is_ignored_block_opening_ = is_ignored_block_opening(config, item)
+
         # if a raw tag first line
-        if not is_block_raw and is_ignored_block_opening(config, item):
+        if not is_block_raw and is_ignored_block_opening_:
             is_raw_first_line = True
 
         # if a raw tag then start ignoring
-        if is_ignored_block_opening(config, item):
+        if is_ignored_block_opening_:
             is_block_raw = True
             ignored_level += 1
 
         if is_script_style_block_opening(config, item):
             in_script_style_tag = True
 
-        if is_safe_closing_tag(config, item):
+        if is_safe_closing_tag_:
             ignored_level -= 1
             ignored_level = max(ignored_level, 0)
             if is_block_raw and ignored_level == 0:
@@ -183,7 +186,7 @@ def indent_html(rawcode: str, config: Config) -> str:
                 flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
             )
             and not is_block_raw
-            and not is_safe_closing_tag(config, item)
+            and not is_safe_closing_tag_
             # and not ending in a slt like <span><strong></strong>.
             and not re.findall(
                 rf"(<({slt_html})>)(.*?)(</(\2)>[^<]*?$)",
@@ -261,9 +264,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             tmp = (indent * indent_level) + item + "\n"
             indent_level += 1
 
-        elif is_raw_first_line or (
-            is_safe_closing_tag(config, item) and not is_block_raw
-        ):
+        elif is_raw_first_line or (is_safe_closing_tag_ and not is_block_raw):
             tmp = (indent * indent_level) + item + "\n"
 
         elif is_block_raw or not item.strip():
@@ -279,7 +280,7 @@ def indent_html(rawcode: str, config: Config) -> str:
 
         # if a opening raw tag then start ignoring.. only if there is no closing tag
         # on the same line
-        if is_ignored_block_opening(config, item):
+        if is_ignored_block_opening_:
             is_block_raw = True
             is_raw_first_line = False
 
@@ -302,7 +303,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             or is_script_style_block_closing(config, item)
         ):
             in_script_style_tag = False
-            if not is_safe_closing_tag(config, item):
+            if not is_safe_closing_tag_:
                 ignored_level -= 1
                 ignored_level = max(ignored_level, 0)
             if ignored_level == 0:


### PR DESCRIPTION
`is_ignored_block_opening(config, item)` and `is_safe_closing_tag(config, item)` are each called multiple times in indent.py with the same parameters. This can be deduplicated.

(Note I've changed the block `with executor_cls(max_workers=worker_count) as exe:` in `__init__.py` to be serial to make the profiler work.
```python
for this_file in file_list:
  file_errors.append(process(config, this_file))
  # if temp_file block etc. is removed
```
# Before:

![image](https://github.com/user-attachments/assets/71f4ba63-8415-463f-9bfc-8a87028aad41)

is_ignored_block_opening (With children): 12.4% of all the time, 61562x calls
is_safe_closing_tag (With children): 6.24% of all the time, 33139x calls

Concrete data:
```
Netbox with serial execution (Patch above): 9.7s
Netbox with unchanged __init__.py              :    4s
OpenEDX platform                                           : 33s
```

# After
![image](https://github.com/user-attachments/assets/f1ef6531-6344-4a8e-bf13-885781937256)

is_ignored_block_opening (With children): 4.73% of all the time, 20622x calls
is_safe_closing_tag (With children): 4.61% of all the time, 20941x calls

Concrete data:
```
Netbox with serial execution (Patch above): 8.3s
Netbox with unchanged __init__.py              : 3.5s
OpenEDX platform                                           : 26s
```

