### PR TITLE
 Performance Improvement 2 - Deduplicate regex flags

### DIFF
--- a/djlint/formatter/attributes.py
+++ b/djlint/formatter/attributes.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import regex as re
 
-from ..helpers import child_of_ignored_block
+from ..helpers import RE_FLAGS_IV, RE_FLAGS_IVM, child_of_ignored_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -39,7 +39,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
         for line_number, line in enumerate(attributes.splitlines()):
             # when checking for template tag, use "match" to force start of line check.
             if re.match(
-                config.template_unindent, line.strip(), flags=re.I | re.X
+                config.template_unindent, line.strip(), flags=RE_FLAGS_IV
             ):
                 indent -= 1
                 tmp = (
@@ -49,7 +49,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
                 )
 
             elif re.match(
-                config.tag_unindent_line, line.strip(), flags=re.I | re.X
+                config.tag_unindent_line, line.strip(), flags=RE_FLAGS_IV
             ):
                 # if we are leaving an indented group, then remove the indent_adder
                 tmp = (
@@ -59,9 +59,9 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
                 )
 
             elif re.search(
-                config.template_indent, line.strip(), flags=re.I | re.X
+                config.template_indent, line.strip(), flags=RE_FLAGS_IV
             ) and not re.search(
-                config.template_unindent, line.strip(), flags=re.I | re.X
+                config.template_unindent, line.strip(), flags=RE_FLAGS_IV
             ):
                 # for open tags, search, but then check that they are not closed.
                 tmp = (
@@ -104,7 +104,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
         + ")[^}]+?[%|}]})",
         func,
         attributes,
-        flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+        flags=RE_FLAGS_IVM,
     )
 
     func = partial(add_break, "after")
@@ -115,7 +115,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
         + ")[^}]+?[%|}]})([^\n]+)$",
         func,
         attributes,
-        flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+        flags=RE_FLAGS_IVM,
     )
     return add_indentation(config, attributes, spacing)
 

--- a/djlint/formatter/attributes.py
+++ b/djlint/formatter/attributes.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import regex as re
 
-from ..helpers import RE_FLAGS_IV, RE_FLAGS_IVM, child_of_ignored_block
+from ..helpers import RE_FLAGS_IMX, RE_FLAGS_IX, child_of_ignored_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -39,7 +39,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
         for line_number, line in enumerate(attributes.splitlines()):
             # when checking for template tag, use "match" to force start of line check.
             if re.match(
-                config.template_unindent, line.strip(), flags=RE_FLAGS_IV
+                config.template_unindent, line.strip(), flags=RE_FLAGS_IX
             ):
                 indent -= 1
                 tmp = (
@@ -49,7 +49,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
                 )
 
             elif re.match(
-                config.tag_unindent_line, line.strip(), flags=RE_FLAGS_IV
+                config.tag_unindent_line, line.strip(), flags=RE_FLAGS_IX
             ):
                 # if we are leaving an indented group, then remove the indent_adder
                 tmp = (
@@ -59,9 +59,9 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
                 )
 
             elif re.search(
-                config.template_indent, line.strip(), flags=RE_FLAGS_IV
+                config.template_indent, line.strip(), flags=RE_FLAGS_IX
             ) and not re.search(
-                config.template_unindent, line.strip(), flags=RE_FLAGS_IV
+                config.template_unindent, line.strip(), flags=RE_FLAGS_IX
             ):
                 # for open tags, search, but then check that they are not closed.
                 tmp = (
@@ -104,7 +104,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
         + ")[^}]+?[%|}]})",
         func,
         attributes,
-        flags=RE_FLAGS_IVM,
+        flags=RE_FLAGS_IMX,
     )
 
     func = partial(add_break, "after")
@@ -115,7 +115,7 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
         + ")[^}]+?[%|}]})([^\n]+)$",
         func,
         attributes,
-        flags=RE_FLAGS_IVM,
+        flags=RE_FLAGS_IMX,
     )
     return add_indentation(config, attributes, spacing)
 
@@ -139,7 +139,7 @@ def format_attributes(config: Config, html: str, match: re.Match[str]) -> str:
 
     # format attributes as groups
     for attr_grp in re.finditer(
-        config.attribute_pattern, match.group(3).strip(), flags=re.VERBOSE
+        config.attribute_pattern, match.group(3).strip(), flags=re.X
     ):
         attrib_name = attr_grp.group(1)
         is_quoted = attr_grp.group(2) and attr_grp.group(2)[0] in {"'", '"'}

--- a/djlint/formatter/compress.py
+++ b/djlint/formatter/compress.py
@@ -11,7 +11,7 @@ import regex as re
 from HtmlTagNames import html_tag_names
 from HtmlVoidElements import html_void_elements
 
-from ..helpers import RE_FLAGS_IVM, child_of_unformatted_block
+from ..helpers import RE_FLAGS_IMX, child_of_unformatted_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -65,4 +65,4 @@ def compress_html(html: str, config: Config) -> str:
 
         return f"{open_bracket}{tag}{attributes}{close_bracket}"
 
-    return re.sub(config.html_tag_regex, _clean_tag, html, flags=RE_FLAGS_IVM)
+    return re.sub(config.html_tag_regex, _clean_tag, html, flags=RE_FLAGS_IMX)

--- a/djlint/formatter/compress.py
+++ b/djlint/formatter/compress.py
@@ -11,7 +11,7 @@ import regex as re
 from HtmlTagNames import html_tag_names
 from HtmlVoidElements import html_void_elements
 
-from ..helpers import child_of_unformatted_block
+from ..helpers import RE_FLAGS_IVM, child_of_unformatted_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -65,9 +65,4 @@ def compress_html(html: str, config: Config) -> str:
 
         return f"{open_bracket}{tag}{attributes}{close_bracket}"
 
-    return re.sub(
-        config.html_tag_regex,
-        _clean_tag,
-        html,
-        flags=re.MULTILINE | re.VERBOSE | re.IGNORECASE,
-    )
+    return re.sub(config.html_tag_regex, _clean_tag, html, flags=RE_FLAGS_IVM)

--- a/djlint/formatter/condense.py
+++ b/djlint/formatter/condense.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING
 import regex as re
 
 from ..helpers import (
-    RE_FLAGS_IMD,
-    RE_FLAGS_IVM,
-    RE_FLAGS_IVMD,
-    RE_FLAGS_MD,
+    RE_FLAGS_IMS,
+    RE_FLAGS_IMSX,
+    RE_FLAGS_IMX,
+    RE_FLAGS_MS,
     inside_ignored_block,
     inside_protected_trans_block,
     is_safe_closing_tag,
@@ -107,7 +107,7 @@ def clean_whitespace(html: str, config: Config) -> str:
                 rf"((?:{{%\s*?{tag.strip()}\b[^}}]+?%}}\n?)+)",
                 func,
                 html,
-                flags=RE_FLAGS_IMD,
+                flags=RE_FLAGS_IMS,
             )
 
     def add_blank_line_before(
@@ -128,7 +128,7 @@ def clean_whitespace(html: str, config: Config) -> str:
                 rf"(?<!^\n)((?:{{%\s*?{tag.strip()}\b[^}}]+?%}}\n?)+)",
                 func,
                 html,
-                flags=RE_FLAGS_IMD,
+                flags=RE_FLAGS_IMS,
             )
 
     # add line after yaml front matter
@@ -143,7 +143,7 @@ def clean_whitespace(html: str, config: Config) -> str:
 
     if not config.no_line_after_yaml:
         func = partial(yaml_add_blank_line_after, html)
-        html = re.sub(r"(^---.+?---)$", func, html, flags=RE_FLAGS_MD)
+        html = re.sub(r"(^---.+?---)$", func, html, flags=RE_FLAGS_MS)
 
     return html
 
@@ -184,7 +184,7 @@ def condense_html(html: str, config: Config) -> str:
                 re.findall(
                     rf"((?:{{%\s*?{tag}[^}}]+?%}}\n?)+)",
                     html,
-                    flags=RE_FLAGS_IMD,
+                    flags=RE_FLAGS_IMS,
                 )
                 for tag in (
                     x.strip() for x in config.blank_line_after_tag.split(",")
@@ -199,7 +199,7 @@ def condense_html(html: str, config: Config) -> str:
                 re.findall(
                     rf"((?:{{%\s*?{tag}[^}}]+?%}}\n?)+)",
                     html,
-                    flags=RE_FLAGS_IMD,
+                    flags=RE_FLAGS_IMS,
                 )
                 for tag in (
                     x.strip() for x in config.blank_line_before_tag.split(",")
@@ -215,7 +215,7 @@ def condense_html(html: str, config: Config) -> str:
         rf"(<({config.optional_single_line_html_tags})\b(?:\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}])*>)\s*([^<\n]*?)\s*?(</(\2)>)",
         func,
         html,
-        flags=RE_FLAGS_IVMD,
+        flags=RE_FLAGS_IMSX,
     )
 
     # put short template tags back on one line. must have leading space
@@ -224,5 +224,5 @@ def condense_html(html: str, config: Config) -> str:
         rf"((?:\s|^){{%-?[ ]*?({config.optional_single_line_template_tags})\b(?:(?!\n|%}}).)*?%}})\s*([^%\n]*?)\s*?({{%-?[ ]+?end(\2)[ ]*?%}})",
         func,
         html,
-        flags=RE_FLAGS_IVM,
+        flags=RE_FLAGS_IMX,
     )

--- a/djlint/formatter/condense.py
+++ b/djlint/formatter/condense.py
@@ -12,6 +12,10 @@ from typing import TYPE_CHECKING
 import regex as re
 
 from ..helpers import (
+    RE_FLAGS_IMD,
+    RE_FLAGS_IVM,
+    RE_FLAGS_IVMD,
+    RE_FLAGS_MD,
     inside_ignored_block,
     inside_protected_trans_block,
     is_safe_closing_tag,
@@ -103,7 +107,7 @@ def clean_whitespace(html: str, config: Config) -> str:
                 rf"((?:{{%\s*?{tag.strip()}\b[^}}]+?%}}\n?)+)",
                 func,
                 html,
-                flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
+                flags=RE_FLAGS_IMD,
             )
 
     def add_blank_line_before(
@@ -124,7 +128,7 @@ def clean_whitespace(html: str, config: Config) -> str:
                 rf"(?<!^\n)((?:{{%\s*?{tag.strip()}\b[^}}]+?%}}\n?)+)",
                 func,
                 html,
-                flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
+                flags=RE_FLAGS_IMD,
             )
 
     # add line after yaml front matter
@@ -139,9 +143,7 @@ def clean_whitespace(html: str, config: Config) -> str:
 
     if not config.no_line_after_yaml:
         func = partial(yaml_add_blank_line_after, html)
-        html = re.sub(
-            r"(^---.+?---)$", func, html, flags=re.MULTILINE | re.DOTALL
-        )
+        html = re.sub(r"(^---.+?---)$", func, html, flags=RE_FLAGS_MD)
 
     return html
 
@@ -182,7 +184,7 @@ def condense_html(html: str, config: Config) -> str:
                 re.findall(
                     rf"((?:{{%\s*?{tag}[^}}]+?%}}\n?)+)",
                     html,
-                    flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
+                    flags=RE_FLAGS_IMD,
                 )
                 for tag in (
                     x.strip() for x in config.blank_line_after_tag.split(",")
@@ -197,7 +199,7 @@ def condense_html(html: str, config: Config) -> str:
                 re.findall(
                     rf"((?:{{%\s*?{tag}[^}}]+?%}}\n?)+)",
                     html,
-                    flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
+                    flags=RE_FLAGS_IMD,
                 )
                 for tag in (
                     x.strip() for x in config.blank_line_before_tag.split(",")
@@ -213,7 +215,7 @@ def condense_html(html: str, config: Config) -> str:
         rf"(<({config.optional_single_line_html_tags})\b(?:\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}])*>)\s*([^<\n]*?)\s*?(</(\2)>)",
         func,
         html,
-        flags=re.IGNORECASE | re.MULTILINE | re.DOTALL | re.VERBOSE,
+        flags=RE_FLAGS_IVMD,
     )
 
     # put short template tags back on one line. must have leading space
@@ -222,5 +224,5 @@ def condense_html(html: str, config: Config) -> str:
         rf"((?:\s|^){{%-?[ ]*?({config.optional_single_line_template_tags})\b(?:(?!\n|%}}).)*?%}})\s*([^%\n]*?)\s*?({{%-?[ ]+?end(\2)[ ]*?%}})",
         func,
         html,
-        flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+        flags=RE_FLAGS_IVM,
     )

--- a/djlint/formatter/css.py
+++ b/djlint/formatter/css.py
@@ -9,7 +9,7 @@ import cssbeautifier
 import regex as re
 from jsbeautifier.javascript.options import BeautifierOptions
 
-from ..helpers import RE_FLAGS_ID, child_of_unformatted_block
+from ..helpers import RE_FLAGS_IS, child_of_unformatted_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -64,5 +64,5 @@ def format_css(html: str, config: Config) -> str:
         r"([ ]*?)(<(?:style)\b(?:\"[^\"]*\"|'[^']*'|{[^}]*}|[^'\">{}])*>)(.*?)(?=</style>)",
         func,
         html,
-        flags=RE_FLAGS_ID,
+        flags=RE_FLAGS_IS,
     )

--- a/djlint/formatter/css.py
+++ b/djlint/formatter/css.py
@@ -9,7 +9,7 @@ import cssbeautifier
 import regex as re
 from jsbeautifier.javascript.options import BeautifierOptions
 
-from ..helpers import child_of_unformatted_block
+from ..helpers import RE_FLAGS_ID, child_of_unformatted_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -64,5 +64,5 @@ def format_css(html: str, config: Config) -> str:
         r"([ ]*?)(<(?:style)\b(?:\"[^\"]*\"|'[^']*'|{[^}]*}|[^'\">{}])*>)(.*?)(?=</style>)",
         func,
         html,
-        flags=re.IGNORECASE | re.DOTALL,
+        flags=RE_FLAGS_ID,
     )

--- a/djlint/formatter/expand.py
+++ b/djlint/formatter/expand.py
@@ -11,7 +11,13 @@ from typing import TYPE_CHECKING
 
 import regex as re
 
-from ..helpers import inside_ignored_block, inside_template_block
+from ..helpers import (
+    RE_FLAGS_IV,
+    RE_FLAGS_IVM,
+    RE_FLAGS_MV,
+    inside_ignored_block,
+    inside_template_block,
+)
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -50,7 +56,7 @@ def expand_html(html: str, config: Config) -> str:
         rf"{break_char}\K(</?(?:{html_tags})\b(\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}])*>)",
         add_left,
         html,
-        flags=re.IGNORECASE | re.VERBOSE,
+        flags=RE_FLAGS_IV,
     )
 
     # html tags - break after
@@ -58,7 +64,7 @@ def expand_html(html: str, config: Config) -> str:
         rf"(</?(?:{html_tags})\b(\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}])*>)(?!\s*?\n)(?=[^\n])",
         add_right,
         html,
-        flags=re.IGNORECASE | re.VERBOSE,
+        flags=RE_FLAGS_IV,
     )
 
     # template tag breaks
@@ -78,7 +84,7 @@ def expand_html(html: str, config: Config) -> str:
             + re.escape(match.group(1))
             + "$",
             html[: match.end()],
-            flags=re.MULTILINE | re.VERBOSE,
+            flags=RE_FLAGS_MV,
         ):
             if out_format == "\n%s" and match.start() == 0:
                 return match.group(1)
@@ -95,7 +101,7 @@ def expand_html(html: str, config: Config) -> str:
         + ")[^}]+?[%}]})",
         partial(should_i_move_template_tag, "\n%s"),
         html,
-        flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+        flags=RE_FLAGS_IVM,
     )
 
     # break after
@@ -105,5 +111,5 @@ def expand_html(html: str, config: Config) -> str:
         + ")[^}]+?[%}]})(?=[^\n])",
         partial(should_i_move_template_tag, "%s\n"),
         html,
-        flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+        flags=RE_FLAGS_IVM,
     )

--- a/djlint/formatter/expand.py
+++ b/djlint/formatter/expand.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING
 import regex as re
 
 from ..helpers import (
-    RE_FLAGS_IV,
-    RE_FLAGS_IVM,
-    RE_FLAGS_MV,
+    RE_FLAGS_IMX,
+    RE_FLAGS_IX,
+    RE_FLAGS_MX,
     inside_ignored_block,
     inside_template_block,
 )
@@ -56,7 +56,7 @@ def expand_html(html: str, config: Config) -> str:
         rf"{break_char}\K(</?(?:{html_tags})\b(\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}])*>)",
         add_left,
         html,
-        flags=RE_FLAGS_IV,
+        flags=RE_FLAGS_IX,
     )
 
     # html tags - break after
@@ -64,7 +64,7 @@ def expand_html(html: str, config: Config) -> str:
         rf"(</?(?:{html_tags})\b(\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}])*>)(?!\s*?\n)(?=[^\n])",
         add_right,
         html,
-        flags=RE_FLAGS_IV,
+        flags=RE_FLAGS_IX,
     )
 
     # template tag breaks
@@ -84,7 +84,7 @@ def expand_html(html: str, config: Config) -> str:
             + re.escape(match.group(1))
             + "$",
             html[: match.end()],
-            flags=RE_FLAGS_MV,
+            flags=RE_FLAGS_MX,
         ):
             if out_format == "\n%s" and match.start() == 0:
                 return match.group(1)
@@ -101,7 +101,7 @@ def expand_html(html: str, config: Config) -> str:
         + ")[^}]+?[%}]})",
         partial(should_i_move_template_tag, "\n%s"),
         html,
-        flags=RE_FLAGS_IVM,
+        flags=RE_FLAGS_IMX,
     )
 
     # break after
@@ -111,5 +111,5 @@ def expand_html(html: str, config: Config) -> str:
         + ")[^}]+?[%}]})(?=[^\n])",
         partial(should_i_move_template_tag, "%s\n"),
         html,
-        flags=RE_FLAGS_IVM,
+        flags=RE_FLAGS_IMX,
     )

--- a/djlint/formatter/indent.py
+++ b/djlint/formatter/indent.py
@@ -9,6 +9,9 @@ import json5 as json
 import regex as re
 
 from ..helpers import (
+    RE_FLAGS_IV,
+    RE_FLAGS_IVM,
+    RE_FLAGS_IVMD,
     inside_ignored_block,
     is_ignored_block_closing,
     is_ignored_block_opening,
@@ -110,7 +113,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             re.findall(
                 rf"^\s*?(?:{config.ignored_inline_blocks})",
                 item,
-                flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+                flags=RE_FLAGS_IVM,
             )
             and not is_block_raw
         ) or (
@@ -139,7 +142,7 @@ def indent_html(rawcode: str, config: Config) -> str:
                     [^<]*?$ # with no other tags following until end of line
                 """,
                     item,
-                    flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+                    flags=RE_FLAGS_IVM,
                 )
             )
             and not is_block_raw
@@ -149,11 +152,7 @@ def indent_html(rawcode: str, config: Config) -> str:
         # closing set tag
         elif (
             not config.no_set_formatting
-            and re.search(
-                r"^(?!.*\{\%).*%\}.*$",
-                item,
-                flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
-            )
+            and re.search(r"^(?!.*\{\%).*%\}.*$", item, flags=RE_FLAGS_IVM)
             and not is_block_raw
             and in_set_tag
         ):
@@ -164,11 +163,7 @@ def indent_html(rawcode: str, config: Config) -> str:
         # closing curly brace inside a set tag
         elif (
             not config.no_set_formatting
-            and re.search(
-                r"^[ ]*}|^[ ]*]",
-                item,
-                flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
-            )
+            and re.search(r"^[ ]*}|^[ ]*]", item, flags=RE_FLAGS_IVM)
             and not is_block_raw
             and in_set_tag
         ):
@@ -177,34 +172,28 @@ def indent_html(rawcode: str, config: Config) -> str:
 
         # if unindent, move left
         elif (
-            re.search(
-                config.tag_unindent,
-                item,
-                flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
-            )
+            re.search(config.tag_unindent, item, flags=RE_FLAGS_IVM)
             and not is_block_raw
             and not is_safe_closing_tag(config, item)
             # and not ending in a slt like <span><strong></strong>.
             and not re.findall(
                 rf"(<({slt_html})>)(.*?)(</(\2)>[^<]*?$)",
                 item,
-                flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+                flags=RE_FLAGS_IVM,
             )
             and not re.findall(
                 rf"(<({slt_html})\\b[^>]+?>)(.*?)(</(\2)>[^<]*?$)",
                 item,
-                flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+                flags=RE_FLAGS_IVM,
             )
         ):
             # block to catch inline block followed by a non-break tag
             if re.findall(
-                rf"(^<({slt_html})>)(.*?)(</(\2)>)",
-                item,
-                flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+                rf"(^<({slt_html})>)(.*?)(</(\2)>)", item, flags=RE_FLAGS_IVM
             ) or re.findall(
                 rf"(^<({slt_html})\b[^>]+?>)(.*?)(</(\2)>)",
                 item,
-                flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+                flags=RE_FLAGS_IVM,
             ):
                 # unindent after instead of before
                 tmp = (indent * indent_level) + item + "\n"
@@ -215,9 +204,7 @@ def indent_html(rawcode: str, config: Config) -> str:
 
         elif (
             re.search(
-                r"^" + str(config.tag_unindent_line),
-                item,
-                flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+                r"^" + str(config.tag_unindent_line), item, flags=RE_FLAGS_IVM
             )
             and not is_block_raw
         ):
@@ -229,9 +216,7 @@ def indent_html(rawcode: str, config: Config) -> str:
         elif (
             not config.no_set_formatting
             and re.search(
-                r"^([ ]*{%[ ]*?set)(?!.*%}).*$",
-                item,
-                flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+                r"^([ ]*{%[ ]*?set)(?!.*%}).*$", item, flags=RE_FLAGS_IVM
             )
             and not is_block_raw
             and not in_set_tag
@@ -246,7 +231,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             and re.search(
                 r"(\{(?![^{}]*%[}\s])(?=[^{}]*$)|\[(?=[^\]]*$))",
                 item,
-                flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+                flags=RE_FLAGS_IVM,
             )
             and not is_block_raw
             and in_set_tag
@@ -254,7 +239,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             re.search(
                 r"^(?:" + str(config.tag_indent) + r")",
                 item,
-                flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE,
+                flags=RE_FLAGS_IVM,
             )
             and not is_block_raw
         ):
@@ -293,7 +278,7 @@ def indent_html(rawcode: str, config: Config) -> str:
                 rf"(\s*?)(<(?:{config.indent_html_tags}))\s((?:\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}\/])+?)(\s?/?>)",
                 func,
                 tmp,
-                flags=re.VERBOSE | re.IGNORECASE,
+                flags=RE_FLAGS_IV,
             )
 
         # turn off raw block if we hit end - for one line raw blocks, but not an inline raw
@@ -451,7 +436,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             r"([ ]*)({%-?)[ ]*(set)[ ]+?((?:(?!%}).)*?)(-?%})",
             func,
             beautified_code,
-            flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE | re.DOTALL,
+            flags=RE_FLAGS_IVMD,
         )
 
     if not config.no_function_formatting:
@@ -461,7 +446,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             r"([ ]*)({{-?\+?)[ ]*?((?:(?!}}).)*?\w)(\((?:\"[^\"]*\"|'[^']*'|[^\)])*?\)[ ]*)((?:\[[^\]]*?\]|\.[^\s]+)[ ]*)?((?:(?!}}).)*?-?\+?}})",
             func,
             beautified_code,
-            flags=re.IGNORECASE | re.MULTILINE | re.VERBOSE | re.DOTALL,
+            flags=RE_FLAGS_IVMD,
         )
 
     if not config.preserve_blank_lines:

--- a/djlint/formatter/indent.py
+++ b/djlint/formatter/indent.py
@@ -9,9 +9,9 @@ import json5 as json
 import regex as re
 
 from ..helpers import (
-    RE_FLAGS_IV,
-    RE_FLAGS_IVM,
-    RE_FLAGS_IVMD,
+    RE_FLAGS_IMSX,
+    RE_FLAGS_IMX,
+    RE_FLAGS_IX,
     inside_ignored_block,
     is_ignored_block_closing,
     is_ignored_block_opening,
@@ -113,7 +113,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             re.findall(
                 rf"^\s*?(?:{config.ignored_inline_blocks})",
                 item,
-                flags=RE_FLAGS_IVM,
+                flags=RE_FLAGS_IMX,
             )
             and not is_block_raw
         ) or (
@@ -142,7 +142,7 @@ def indent_html(rawcode: str, config: Config) -> str:
                     [^<]*?$ # with no other tags following until end of line
                 """,
                     item,
-                    flags=RE_FLAGS_IVM,
+                    flags=RE_FLAGS_IMX,
                 )
             )
             and not is_block_raw
@@ -152,7 +152,7 @@ def indent_html(rawcode: str, config: Config) -> str:
         # closing set tag
         elif (
             not config.no_set_formatting
-            and re.search(r"^(?!.*\{\%).*%\}.*$", item, flags=RE_FLAGS_IVM)
+            and re.search(r"^(?!.*\{\%).*%\}.*$", item, flags=RE_FLAGS_IMX)
             and not is_block_raw
             and in_set_tag
         ):
@@ -163,7 +163,7 @@ def indent_html(rawcode: str, config: Config) -> str:
         # closing curly brace inside a set tag
         elif (
             not config.no_set_formatting
-            and re.search(r"^[ ]*}|^[ ]*]", item, flags=RE_FLAGS_IVM)
+            and re.search(r"^[ ]*}|^[ ]*]", item, flags=RE_FLAGS_IMX)
             and not is_block_raw
             and in_set_tag
         ):
@@ -172,28 +172,28 @@ def indent_html(rawcode: str, config: Config) -> str:
 
         # if unindent, move left
         elif (
-            re.search(config.tag_unindent, item, flags=RE_FLAGS_IVM)
+            re.search(config.tag_unindent, item, flags=RE_FLAGS_IMX)
             and not is_block_raw
             and not is_safe_closing_tag(config, item)
             # and not ending in a slt like <span><strong></strong>.
             and not re.findall(
                 rf"(<({slt_html})>)(.*?)(</(\2)>[^<]*?$)",
                 item,
-                flags=RE_FLAGS_IVM,
+                flags=RE_FLAGS_IMX,
             )
             and not re.findall(
                 rf"(<({slt_html})\\b[^>]+?>)(.*?)(</(\2)>[^<]*?$)",
                 item,
-                flags=RE_FLAGS_IVM,
+                flags=RE_FLAGS_IMX,
             )
         ):
             # block to catch inline block followed by a non-break tag
             if re.findall(
-                rf"(^<({slt_html})>)(.*?)(</(\2)>)", item, flags=RE_FLAGS_IVM
+                rf"(^<({slt_html})>)(.*?)(</(\2)>)", item, flags=RE_FLAGS_IMX
             ) or re.findall(
                 rf"(^<({slt_html})\b[^>]+?>)(.*?)(</(\2)>)",
                 item,
-                flags=RE_FLAGS_IVM,
+                flags=RE_FLAGS_IMX,
             ):
                 # unindent after instead of before
                 tmp = (indent * indent_level) + item + "\n"
@@ -204,7 +204,7 @@ def indent_html(rawcode: str, config: Config) -> str:
 
         elif (
             re.search(
-                r"^" + str(config.tag_unindent_line), item, flags=RE_FLAGS_IVM
+                r"^" + str(config.tag_unindent_line), item, flags=RE_FLAGS_IMX
             )
             and not is_block_raw
         ):
@@ -216,7 +216,7 @@ def indent_html(rawcode: str, config: Config) -> str:
         elif (
             not config.no_set_formatting
             and re.search(
-                r"^([ ]*{%[ ]*?set)(?!.*%}).*$", item, flags=RE_FLAGS_IVM
+                r"^([ ]*{%[ ]*?set)(?!.*%}).*$", item, flags=RE_FLAGS_IMX
             )
             and not is_block_raw
             and not in_set_tag
@@ -231,7 +231,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             and re.search(
                 r"(\{(?![^{}]*%[}\s])(?=[^{}]*$)|\[(?=[^\]]*$))",
                 item,
-                flags=RE_FLAGS_IVM,
+                flags=RE_FLAGS_IMX,
             )
             and not is_block_raw
             and in_set_tag
@@ -239,7 +239,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             re.search(
                 r"^(?:" + str(config.tag_indent) + r")",
                 item,
-                flags=RE_FLAGS_IVM,
+                flags=RE_FLAGS_IMX,
             )
             and not is_block_raw
         ):
@@ -278,7 +278,7 @@ def indent_html(rawcode: str, config: Config) -> str:
                 rf"(\s*?)(<(?:{config.indent_html_tags}))\s((?:\"[^\"]*\"|'[^']*'|{{[^}}]*}}|[^'\">{{}}\/])+?)(\s?/?>)",
                 func,
                 tmp,
-                flags=RE_FLAGS_IV,
+                flags=RE_FLAGS_IX,
             )
 
         # turn off raw block if we hit end - for one line raw blocks, but not an inline raw
@@ -296,7 +296,7 @@ def indent_html(rawcode: str, config: Config) -> str:
         # detect the outer quotes for jinja
         if config.profile == "jinja":
             matches = re.findall(
-                r"=([\"'])(\{\{[\s\S]*?\}\})\1", tmp, flags=re.MULTILINE
+                r"=([\"'])(\{\{[\s\S]*?\}\})\1", tmp, flags=re.M
             )
 
             for match in matches:
@@ -436,7 +436,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             r"([ ]*)({%-?)[ ]*(set)[ ]+?((?:(?!%}).)*?)(-?%})",
             func,
             beautified_code,
-            flags=RE_FLAGS_IVMD,
+            flags=RE_FLAGS_IMSX,
         )
 
     if not config.no_function_formatting:
@@ -446,7 +446,7 @@ def indent_html(rawcode: str, config: Config) -> str:
             r"([ ]*)({{-?\+?)[ ]*?((?:(?!}}).)*?\w)(\((?:\"[^\"]*\"|'[^']*'|[^\)])*?\)[ ]*)((?:\[[^\]]*?\]|\.[^\s]+)[ ]*)?((?:(?!}}).)*?-?\+?}})",
             func,
             beautified_code,
-            flags=RE_FLAGS_IVMD,
+            flags=RE_FLAGS_IMSX,
         )
 
     if not config.preserve_blank_lines:

--- a/djlint/formatter/js.py
+++ b/djlint/formatter/js.py
@@ -9,7 +9,7 @@ import jsbeautifier
 import regex as re
 from jsbeautifier.javascript.options import BeautifierOptions
 
-from ..helpers import child_of_unformatted_block
+from ..helpers import RE_FLAGS_ID, child_of_unformatted_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -64,5 +64,5 @@ def format_js(html: str, config: Config) -> str:
         r"([ ]*?)(<(?:script)\b(?:\"[^\"]*\"|'[^']*'|{[^}]*}|[^'\">{}])*>)(.*?)(?=</script>)",
         func,
         html,
-        flags=re.IGNORECASE | re.DOTALL,
+        flags=RE_FLAGS_ID,
     )

--- a/djlint/formatter/js.py
+++ b/djlint/formatter/js.py
@@ -9,7 +9,7 @@ import jsbeautifier
 import regex as re
 from jsbeautifier.javascript.options import BeautifierOptions
 
-from ..helpers import RE_FLAGS_ID, child_of_unformatted_block
+from ..helpers import RE_FLAGS_IS, child_of_unformatted_block
 
 if TYPE_CHECKING:
     from ..settings import Config
@@ -64,5 +64,5 @@ def format_js(html: str, config: Config) -> str:
         r"([ ]*?)(<(?:script)\b(?:\"[^\"]*\"|'[^']*'|{[^}]*}|[^'\">{}])*>)(.*?)(?=</script>)",
         func,
         html,
-        flags=RE_FLAGS_ID,
+        flags=RE_FLAGS_IS,
     )

--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -221,9 +221,7 @@ def inside_template_block(
     match_start = match.start()
     match_end = match.end(0)
     for ignored_match in re.finditer(
-        config.template_blocks,
-        html,
-        flags=RE_FLAGS_IMSX,
+        config.template_blocks, html, flags=RE_FLAGS_IMSX
     ):
         if (
             ignored_match.start(0) <= match_start

--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -139,7 +139,7 @@ def inside_protected_trans_block(
     # return re.search(
     #     config.ignored_trans_blocks_closing,
     #     html[last_index:],
-    #     flags=RE_FLAGS_IV,
+    #     flags=RE_FLAGS_IX,
     # )
 
 

--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -10,16 +10,18 @@ from typing import TYPE_CHECKING
 import regex as re
 
 if TYPE_CHECKING:
+    from typing import Final
+
     from .settings import Config
 
-RE_FLAGS_IVMD = re.IGNORECASE | re.VERBOSE | re.MULTILINE | re.DOTALL
-RE_FLAGS_IVD = re.IGNORECASE | re.VERBOSE | re.DOTALL
-RE_FLAGS_IV = re.IGNORECASE | re.VERBOSE
-RE_FLAGS_IVM = re.IGNORECASE | re.VERBOSE | re.MULTILINE
-RE_FLAGS_MD = re.MULTILINE | re.DOTALL
-RE_FLAGS_IMD = re.IGNORECASE | re.MULTILINE | re.DOTALL
-RE_FLAGS_ID = re.IGNORECASE | re.DOTALL
-RE_FLAGS_MV = re.MULTILINE | re.VERBOSE
+RE_FLAGS_IS: Final = re.I | re.S
+RE_FLAGS_IX: Final = re.I | re.X
+RE_FLAGS_MS: Final = re.M | re.S
+RE_FLAGS_MX: Final = re.M | re.X
+RE_FLAGS_IMS: Final = re.I | re.M | re.S
+RE_FLAGS_IMX: Final = re.I | re.M | re.X
+RE_FLAGS_ISX: Final = re.I | re.S | re.X
+RE_FLAGS_IMSX: Final = re.I | re.M | re.S | re.X
 
 
 def is_ignored_block_opening(config: Config, item: str) -> bool:
@@ -30,7 +32,7 @@ def is_ignored_block_opening(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(config.ignored_blocks_inline, item, flags=RE_FLAGS_IVMD)
+        re.finditer(config.ignored_blocks_inline, item, flags=RE_FLAGS_IMSX)
     )
 
     if inline:
@@ -40,7 +42,7 @@ def is_ignored_block_opening(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.ignored_block_opening, item[last_index:], flags=RE_FLAGS_IV
+            config.ignored_block_opening, item[last_index:], flags=RE_FLAGS_IX
         )
     )
 
@@ -53,7 +55,7 @@ def is_script_style_block_opening(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(config.script_style_inline, item, flags=RE_FLAGS_IVMD)
+        re.finditer(config.script_style_inline, item, flags=RE_FLAGS_IMSX)
     )
 
     if inline:
@@ -63,7 +65,7 @@ def is_script_style_block_opening(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.script_style_opening, item[last_index:], flags=RE_FLAGS_IV
+            config.script_style_opening, item[last_index:], flags=RE_FLAGS_IX
         )
     )
 
@@ -81,18 +83,18 @@ def inside_protected_trans_block(
     """
     last_index = 0
     close_block = re.search(
-        config.ignored_trans_blocks_closing, match.group(), flags=RE_FLAGS_IV
+        config.ignored_trans_blocks_closing, match.group(), flags=RE_FLAGS_IX
     )
 
     if not close_block:
         return False
 
     non_trimmed = tuple(
-        re.finditer(config.ignored_trans_blocks, html, flags=RE_FLAGS_IVD)
+        re.finditer(config.ignored_trans_blocks, html, flags=RE_FLAGS_ISX)
     )
 
     trimmed = tuple(
-        re.finditer(config.trans_trimmed_blocks, html, flags=RE_FLAGS_IVD)
+        re.finditer(config.trans_trimmed_blocks, html, flags=RE_FLAGS_ISX)
     )
 
     # who is max?
@@ -103,7 +105,7 @@ def inside_protected_trans_block(
         # check that this is not an inline block.
         non_trimmed_inline = any(
             re.finditer(
-                config.ignored_trans_blocks, match.group(), flags=RE_FLAGS_IVD
+                config.ignored_trans_blocks, match.group(), flags=RE_FLAGS_ISX
             )
         )
 
@@ -116,7 +118,7 @@ def inside_protected_trans_block(
                 re.search(
                     config.ignored_trans_blocks_closing,
                     html[last_index:],
-                    flags=RE_FLAGS_IV,
+                    flags=RE_FLAGS_IX,
                 )
             )
 
@@ -149,7 +151,7 @@ def is_ignored_block_closing(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(config.ignored_inline_blocks, item, flags=RE_FLAGS_IV)
+        re.finditer(config.ignored_inline_blocks, item, flags=RE_FLAGS_IX)
     )
 
     if inline:
@@ -159,7 +161,7 @@ def is_ignored_block_closing(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.ignored_block_closing, item[last_index:], flags=RE_FLAGS_IV
+            config.ignored_block_closing, item[last_index:], flags=RE_FLAGS_IX
         )
     )
 
@@ -172,7 +174,7 @@ def is_script_style_block_closing(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(config.script_style_inline, item, flags=RE_FLAGS_IV)
+        re.finditer(config.script_style_inline, item, flags=RE_FLAGS_IX)
     )
 
     if inline:
@@ -182,7 +184,7 @@ def is_script_style_block_closing(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.script_style_closing, item[last_index:], flags=RE_FLAGS_IV
+            config.script_style_closing, item[last_index:], flags=RE_FLAGS_IX
         )
     )
 
@@ -198,7 +200,7 @@ def is_safe_closing_tag(config: Config, item: str) -> bool:
         re.finditer(
             config.ignored_inline_blocks + r" | " + config.ignored_blocks,
             item,
-            flags=RE_FLAGS_IVMD,
+            flags=RE_FLAGS_IMSX,
         )
     )
 
@@ -208,7 +210,7 @@ def is_safe_closing_tag(config: Config, item: str) -> bool:
         )  # get the last index. The ignored opening should start after this.
 
     return bool(
-        re.search(config.safe_closing_tag, item[last_index:], flags=RE_FLAGS_IV)
+        re.search(config.safe_closing_tag, item[last_index:], flags=RE_FLAGS_IX)
     )
 
 
@@ -222,7 +224,7 @@ def inside_template_block(
         ignored_match.start(0) <= match_start
         and match_end <= ignored_match.end()
         for ignored_match in re.finditer(
-            config.template_blocks, html, flags=RE_FLAGS_IVMD
+            config.template_blocks, html, flags=RE_FLAGS_IMSX
         )
     )
 
@@ -237,7 +239,7 @@ def inside_ignored_linter_block(
         ignored_match.start(0) <= match_start
         and match_end <= ignored_match.end()
         for ignored_match in re.finditer(
-            config.ignored_linter_blocks, html, flags=RE_FLAGS_IVMD
+            config.ignored_linter_blocks, html, flags=RE_FLAGS_IMSX
         )
     )
 
@@ -249,8 +251,8 @@ def _inside_ignored_block(
     return tuple(
         (x.start(0), x.end())
         for x in itertools.chain(
-            re.finditer(ignored_blocks, html, flags=RE_FLAGS_IVMD),
-            re.finditer(ignored_inline_blocks, html, flags=RE_FLAGS_IV),
+            re.finditer(ignored_blocks, html, flags=RE_FLAGS_IMSX),
+            re.finditer(ignored_inline_blocks, html, flags=RE_FLAGS_IX),
         )
     )
 
@@ -277,7 +279,7 @@ def _child_of_unformatted_block(
 ) -> tuple[tuple[int, int], ...]:
     return tuple(
         (x.start(0), x.end())
-        for x in re.finditer(unformatted_blocks, html, flags=RE_FLAGS_IVMD)
+        for x in re.finditer(unformatted_blocks, html, flags=RE_FLAGS_IMSX)
     )
 
 
@@ -305,8 +307,8 @@ def child_of_ignored_block(
         ignored_match.start(0) < match_start
         and match_end <= ignored_match.end()
         for ignored_match in itertools.chain(
-            re.finditer(config.ignored_blocks, html, flags=RE_FLAGS_IVMD),
-            re.finditer(config.ignored_inline_blocks, html, flags=RE_FLAGS_IV),
+            re.finditer(config.ignored_blocks, html, flags=RE_FLAGS_IMSX),
+            re.finditer(config.ignored_inline_blocks, html, flags=RE_FLAGS_IX),
         )
     )
 
@@ -323,8 +325,8 @@ def overlaps_ignored_block(
         (ignored_match.start(0) <= match_start <= ignored_match.end())
         or (ignored_match.start() <= match_end <= ignored_match.end())
         for ignored_match in itertools.chain(
-            re.finditer(config.ignored_blocks, html, flags=RE_FLAGS_IVMD),
-            re.finditer(config.ignored_inline_blocks, html, flags=RE_FLAGS_IV),
+            re.finditer(config.ignored_blocks, html, flags=RE_FLAGS_IMSX),
+            re.finditer(config.ignored_inline_blocks, html, flags=RE_FLAGS_IX),
         )
     )
 
@@ -345,5 +347,5 @@ def inside_ignored_rule(
             and (ignored_match.start(0) <= match_end <= ignored_match.end())
         )
         for rule_regex in config.ignored_rules
-        for ignored_match in re.finditer(rule_regex, html, flags=RE_FLAGS_IVD)
+        for ignored_match in re.finditer(rule_regex, html, flags=RE_FLAGS_ISX)
     )

--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -12,6 +12,15 @@ import regex as re
 if TYPE_CHECKING:
     from .settings import Config
 
+RE_FLAGS_IVMD = re.IGNORECASE | re.VERBOSE | re.MULTILINE | re.DOTALL
+RE_FLAGS_IVD = re.IGNORECASE | re.VERBOSE | re.DOTALL
+RE_FLAGS_IV = re.IGNORECASE | re.VERBOSE
+RE_FLAGS_IVM = re.IGNORECASE | re.VERBOSE | re.MULTILINE
+RE_FLAGS_MD = re.MULTILINE | re.DOTALL
+RE_FLAGS_IMD = re.IGNORECASE | re.MULTILINE | re.DOTALL
+RE_FLAGS_ID = re.IGNORECASE | re.DOTALL
+RE_FLAGS_MV = re.MULTILINE | re.VERBOSE
+
 
 def is_ignored_block_opening(config: Config, item: str) -> bool:
     """Find ignored group opening.
@@ -21,11 +30,7 @@ def is_ignored_block_opening(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(
-            config.ignored_blocks_inline,
-            item,
-            flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE | re.DOTALL,
-        )
+        re.finditer(config.ignored_blocks_inline, item, flags=RE_FLAGS_IVMD)
     )
 
     if inline:
@@ -35,9 +40,7 @@ def is_ignored_block_opening(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.ignored_block_opening,
-            item[last_index:],
-            flags=re.IGNORECASE | re.VERBOSE,
+            config.ignored_block_opening, item[last_index:], flags=RE_FLAGS_IV
         )
     )
 
@@ -50,11 +53,7 @@ def is_script_style_block_opening(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(
-            config.script_style_inline,
-            item,
-            flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE | re.DOTALL,
-        )
+        re.finditer(config.script_style_inline, item, flags=RE_FLAGS_IVMD)
     )
 
     if inline:
@@ -64,9 +63,7 @@ def is_script_style_block_opening(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.script_style_opening,
-            item[last_index:],
-            flags=re.IGNORECASE | re.VERBOSE,
+            config.script_style_opening, item[last_index:], flags=RE_FLAGS_IV
         )
     )
 
@@ -84,28 +81,18 @@ def inside_protected_trans_block(
     """
     last_index = 0
     close_block = re.search(
-        config.ignored_trans_blocks_closing,
-        match.group(),
-        flags=re.IGNORECASE | re.VERBOSE,
+        config.ignored_trans_blocks_closing, match.group(), flags=RE_FLAGS_IV
     )
 
     if not close_block:
         return False
 
     non_trimmed = tuple(
-        re.finditer(
-            config.ignored_trans_blocks,
-            html,
-            flags=re.IGNORECASE | re.VERBOSE | re.DOTALL,
-        )
+        re.finditer(config.ignored_trans_blocks, html, flags=RE_FLAGS_IVD)
     )
 
     trimmed = tuple(
-        re.finditer(
-            config.trans_trimmed_blocks,
-            html,
-            flags=re.IGNORECASE | re.VERBOSE | re.DOTALL,
-        )
+        re.finditer(config.trans_trimmed_blocks, html, flags=RE_FLAGS_IVD)
     )
 
     # who is max?
@@ -116,9 +103,7 @@ def inside_protected_trans_block(
         # check that this is not an inline block.
         non_trimmed_inline = any(
             re.finditer(
-                config.ignored_trans_blocks,
-                match.group(),
-                flags=re.IGNORECASE | re.VERBOSE | re.DOTALL,
+                config.ignored_trans_blocks, match.group(), flags=RE_FLAGS_IVD
             )
         )
 
@@ -131,7 +116,7 @@ def inside_protected_trans_block(
                 re.search(
                     config.ignored_trans_blocks_closing,
                     html[last_index:],
-                    flags=re.IGNORECASE | re.VERBOSE,
+                    flags=RE_FLAGS_IV,
                 )
             )
 
@@ -152,7 +137,7 @@ def inside_protected_trans_block(
     # return re.search(
     #     config.ignored_trans_blocks_closing,
     #     html[last_index:],
-    #     flags=re.IGNORECASE | re.VERBOSE,
+    #     flags=RE_FLAGS_IV,
     # )
 
 
@@ -164,9 +149,7 @@ def is_ignored_block_closing(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(
-            config.ignored_inline_blocks, item, flags=re.IGNORECASE | re.VERBOSE
-        )
+        re.finditer(config.ignored_inline_blocks, item, flags=RE_FLAGS_IV)
     )
 
     if inline:
@@ -176,9 +159,7 @@ def is_ignored_block_closing(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.ignored_block_closing,
-            item[last_index:],
-            flags=re.IGNORECASE | re.VERBOSE,
+            config.ignored_block_closing, item[last_index:], flags=RE_FLAGS_IV
         )
     )
 
@@ -191,9 +172,7 @@ def is_script_style_block_closing(config: Config, item: str) -> bool:
     """
     last_index = 0
     inline = tuple(
-        re.finditer(
-            config.script_style_inline, item, flags=re.IGNORECASE | re.VERBOSE
-        )
+        re.finditer(config.script_style_inline, item, flags=RE_FLAGS_IV)
     )
 
     if inline:
@@ -203,9 +182,7 @@ def is_script_style_block_closing(config: Config, item: str) -> bool:
 
     return bool(
         re.search(
-            config.script_style_closing,
-            item[last_index:],
-            flags=re.IGNORECASE | re.VERBOSE,
+            config.script_style_closing, item[last_index:], flags=RE_FLAGS_IV
         )
     )
 
@@ -221,7 +198,7 @@ def is_safe_closing_tag(config: Config, item: str) -> bool:
         re.finditer(
             config.ignored_inline_blocks + r" | " + config.ignored_blocks,
             item,
-            flags=re.IGNORECASE | re.VERBOSE | re.MULTILINE | re.DOTALL,
+            flags=RE_FLAGS_IVMD,
         )
     )
 
@@ -231,11 +208,7 @@ def is_safe_closing_tag(config: Config, item: str) -> bool:
         )  # get the last index. The ignored opening should start after this.
 
     return bool(
-        re.search(
-            config.safe_closing_tag,
-            item[last_index:],
-            flags=re.IGNORECASE | re.VERBOSE,
-        )
+        re.search(config.safe_closing_tag, item[last_index:], flags=RE_FLAGS_IV)
     )
 
 
@@ -249,9 +222,7 @@ def inside_template_block(
         ignored_match.start(0) <= match_start
         and match_end <= ignored_match.end()
         for ignored_match in re.finditer(
-            config.template_blocks,
-            html,
-            flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+            config.template_blocks, html, flags=RE_FLAGS_IVMD
         )
     )
 
@@ -266,9 +237,7 @@ def inside_ignored_linter_block(
         ignored_match.start(0) <= match_start
         and match_end <= ignored_match.end()
         for ignored_match in re.finditer(
-            config.ignored_linter_blocks,
-            html,
-            flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+            config.ignored_linter_blocks, html, flags=RE_FLAGS_IVMD
         )
     )
 
@@ -280,14 +249,8 @@ def _inside_ignored_block(
     return tuple(
         (x.start(0), x.end())
         for x in itertools.chain(
-            re.finditer(
-                ignored_blocks,
-                html,
-                flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
-            ),
-            re.finditer(
-                ignored_inline_blocks, html, flags=re.IGNORECASE | re.VERBOSE
-            ),
+            re.finditer(ignored_blocks, html, flags=RE_FLAGS_IVMD),
+            re.finditer(ignored_inline_blocks, html, flags=RE_FLAGS_IV),
         )
     )
 
@@ -314,11 +277,7 @@ def _child_of_unformatted_block(
 ) -> tuple[tuple[int, int], ...]:
     return tuple(
         (x.start(0), x.end())
-        for x in re.finditer(
-            unformatted_blocks,
-            html,
-            flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
-        )
+        for x in re.finditer(unformatted_blocks, html, flags=RE_FLAGS_IVMD)
     )
 
 
@@ -346,16 +305,8 @@ def child_of_ignored_block(
         ignored_match.start(0) < match_start
         and match_end <= ignored_match.end()
         for ignored_match in itertools.chain(
-            re.finditer(
-                config.ignored_blocks,
-                html,
-                flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
-            ),
-            re.finditer(
-                config.ignored_inline_blocks,
-                html,
-                flags=re.IGNORECASE | re.VERBOSE,
-            ),
+            re.finditer(config.ignored_blocks, html, flags=RE_FLAGS_IVMD),
+            re.finditer(config.ignored_inline_blocks, html, flags=RE_FLAGS_IV),
         )
     )
 
@@ -372,20 +323,8 @@ def overlaps_ignored_block(
         (ignored_match.start(0) <= match_start <= ignored_match.end())
         or (ignored_match.start() <= match_end <= ignored_match.end())
         for ignored_match in itertools.chain(
-            re.finditer(
-                config.ignored_blocks,
-                html,
-                flags=re.DOTALL
-                | re.IGNORECASE
-                | re.VERBOSE
-                | re.MULTILINE
-                | re.DOTALL,
-            ),
-            re.finditer(
-                config.ignored_inline_blocks,
-                html,
-                flags=re.IGNORECASE | re.VERBOSE,
-            ),
+            re.finditer(config.ignored_blocks, html, flags=RE_FLAGS_IVMD),
+            re.finditer(config.ignored_inline_blocks, html, flags=RE_FLAGS_IV),
         )
     )
 
@@ -406,7 +345,5 @@ def inside_ignored_rule(
             and (ignored_match.start(0) <= match_end <= ignored_match.end())
         )
         for rule_regex in config.ignored_rules
-        for ignored_match in re.finditer(
-            rule_regex, html, flags=re.DOTALL | re.IGNORECASE | re.VERBOSE
-        )
+        for ignored_match in re.finditer(rule_regex, html, flags=RE_FLAGS_IVD)
     )

--- a/djlint/lint.py
+++ b/djlint/lint.py
@@ -78,7 +78,7 @@ def linter(
 
     # remove ignored rules for file
     for pattern, rules in config.per_file_ignores.items():
-        if re.search(pattern, filepath, flags=re.VERBOSE):
+        if re.search(pattern, filepath, flags=re.X):
             ignored_rules.update(x.strip() for x in rules.split(","))
 
     for rule in config.linter_rules:
@@ -110,9 +110,7 @@ def linter(
         else:
             for pattern in rule["patterns"]:
                 for match in re.finditer(
-                    pattern,
-                    html,
-                    flags=build_flags(rule.get("flags", "re.DOTALL")),
+                    pattern, html, flags=build_flags(rule.get("flags", "re.S"))
                 ):
                     if (
                         not overlaps_ignored_block(config, html, match)

--- a/djlint/rules/H025.py
+++ b/djlint/rules/H025.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import regex as re
 
 from ..helpers import (
+    RE_FLAGS_IX,
     inside_ignored_linter_block,
     inside_ignored_rule,
     overlaps_ignored_block,
@@ -38,12 +39,12 @@ def run(
     for match in re.finditer(
         r"<(/?(\w+))\s*(" + config.attribute_pattern + r"|\s*)*\s*?>",
         html,
-        flags=re.VERBOSE,
+        flags=re.X,
     ):
         if match.group(1) and not re.search(
             rf"^/?{config.always_self_closing_html_tags}\b",
             match.group(1),
-            flags=re.I | re.X,
+            flags=RE_FLAGS_IX,
         ):
             # close tags should equal open tags
             if match.group(1)[0] != "/":

--- a/djlint/src.py
+++ b/djlint/src.py
@@ -44,7 +44,7 @@ def get_src(src: Iterable[Path], config: Config) -> list[Path]:
         paths.extend(
             x
             for x in normalized_item.glob(f"**/*.{extension}")
-            if not re.search(config.exclude, x.as_posix(), flags=re.VERBOSE)
+            if not re.search(config.exclude, x.as_posix(), flags=re.X)
             and no_pragma(config, x)
             and (
                 (config.use_gitignore and not config.gitignore.match_file(x))


### PR DESCRIPTION
See #986 for details.



The problem is, that each OR of the enum flags is extremely expensive for some reason.

![image](https://github.com/user-attachments/assets/d889eb04-b3bd-4440-9c50-bc871f2c1cb3)


You can see that, the `enum.__or__` is called 975773x times for Netbox (That's the base repo I use for measurements) and takes 9.58% of the entire runtime.

After this patch, `enum.__or__` is called only 30768x times. This is outside of the graph rendered by gprof2dot, so here you have a screenshot from snakeviz :)

![image](https://github.com/user-attachments/assets/cd70b1e8-8f55-4a91-9aa7-63c9d70d9317)

New numbers: (Without the perf-1 branch applied), small but nevertheless somewhat impactful.
Netbox, parallel: 3.8s
EDX platform: 31s