### PR TITLE
Performance Improvement 3 - Refactor some any()s to for loops

### DIFF
--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -245,15 +245,17 @@ def inside_template_block(
     """Check if a re.Match is inside of a template block."""
     match_start = match.start()
     match_end = match.end(0)
-    return any(
-        ignored_match.start(0) <= match_start
-        and match_end <= ignored_match.end()
-        for ignored_match in re.finditer(
-            config.template_blocks,
-            html,
-            flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
-        )
-    )
+    for ignored_match in re.finditer(
+        config.template_blocks,
+        html,
+        flags=re.DOTALL | re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+    ):
+        if (
+            ignored_match.start(0) <= match_start
+            and match_end <= ignored_match.end()
+        ):
+            return True
+    return False
 
 
 def inside_ignored_linter_block(
@@ -298,14 +300,17 @@ def inside_ignored_block(
     """Do not add whitespace if the tag is in a non indent block."""
     match_start = match.start()
     match_end = match.end(0)
-    return any(
-        ignored_match_start <= match_start and match_end <= ignored_match_end
-        for ignored_match_start, ignored_match_end in _inside_ignored_block(
-            html,
-            ignored_blocks=config.ignored_blocks,
-            ignored_inline_blocks=config.ignored_inline_blocks,
-        )
-    )
+    for ignored_match_start, ignored_match_end in _inside_ignored_block(
+        html,
+        ignored_blocks=config.ignored_blocks,
+        ignored_inline_blocks=config.ignored_inline_blocks,
+    ):
+        if (
+            ignored_match_start <= match_start
+            and match_end <= ignored_match_end
+        ):
+            return True
+    return False
 
 
 @cache
@@ -328,12 +333,15 @@ def child_of_unformatted_block(
     """Do not add whitespace if the tag is in a non indent block."""
     match_start = match.start()
     match_end = match.end(0)
-    return any(
-        ignored_match_start < match_start and match_end <= ignored_match_end
-        for ignored_match_start, ignored_match_end in _child_of_unformatted_block(
-            html, unformatted_blocks=config.unformatted_blocks
-        )
-    )
+    for ignored_match_start, ignored_match_end in _child_of_unformatted_block(
+        html, unformatted_blocks=config.unformatted_blocks
+    ):
+        if (
+            ignored_match_start <= match_start
+            and match_end <= ignored_match_end
+        ):
+            return True
+    return False
 
 
 def child_of_ignored_block(

--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -337,7 +337,7 @@ def child_of_unformatted_block(
         html, unformatted_blocks=config.unformatted_blocks
     ):
         if (
-            ignored_match_start <= match_start
+            ignored_match_start < match_start
             and match_end <= ignored_match_end
         ):
             return True

--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -336,10 +336,7 @@ def child_of_unformatted_block(
     for ignored_match_start, ignored_match_end in _child_of_unformatted_block(
         html, unformatted_blocks=config.unformatted_blocks
     ):
-        if (
-            ignored_match_start < match_start
-            and match_end <= ignored_match_end
-        ):
+        if ignored_match_start < match_start and match_end <= ignored_match_end:
             return True
     return False
 


### PR DESCRIPTION
I only modified the hot functions, but can modify all to use for loops if you want. See #986 for more information.

Before:
![image](https://github.com/user-attachments/assets/380fb4fa-a69b-41a1-9048-6bb7ea89f6e9)

After:

![image](https://github.com/user-attachments/assets/ba22dfef-a328-47cc-b3d5-b2550177aeae)


Performance numbers:
Netbox, parallel: 3.7-3.8s
EDX platform, parallel: 25s

As you can see, most of the time is now spent compiling/looking up regex in the caches (Addressed by Performance Improvement 5)


I will wait with Performance Improvement 4 and 5 until the first three are merged.