### PR TITLE
Performance Improvement 4: Take advantage of short circuiting

### DIFF
--- a/djlint/formatter/attributes.py
+++ b/djlint/formatter/attributes.py
@@ -123,9 +123,10 @@ def format_template_tags(config: Config, attributes: str, spacing: int) -> str:
 def format_attributes(config: Config, html: str, match: re.Match[str]) -> str:
     """Spread long attributes over multiple lines."""
     # check that we are not inside an ignored block
-    if (
-        child_of_ignored_block(config, html, match)
-        or len(match.group(3).strip()) < config.max_attribute_length
+    if len(
+        match.group(3).strip()
+    ) < config.max_attribute_length or child_of_ignored_block(
+        config, html, match
     ):
         return match.group()
 

--- a/djlint/formatter/condense.py
+++ b/djlint/formatter/condense.py
@@ -168,8 +168,8 @@ def condense_html(html: str, config: Config) -> str:
             )
 
         if (
-            not inside_ignored_block(config, html, match)
-            and combined_length < config.max_line_length
+            combined_length < config.max_line_length
+            and not inside_ignored_block(config, html, match)
             and if_blank_line_after_match(config, match.group(3))
             and if_blank_line_before_match(config, match.group(3))
         ):


### PR DESCRIPTION
This converts:
```python
if expensive_op() and cheap_op():
```
into
```python
if cheap_op() and expensive_op():
```
to reduce the amount of regex usages.

Before:
![image](https://github.com/user-attachments/assets/a41e97f6-2d0b-4469-928c-b5eae166f1f3)

regex.search: 295.046x times
regex.finditer: 132.403x times
regex._compile: 453.193x times

After:
![image](https://github.com/user-attachments/assets/5a60119b-4d0d-4a98-bb1c-292fe9357e08)


regex.search: 242.293x times
regex.finditer 124.641x times
regex._compile: 392.678x times

The new timings:
EDX, parallel: 21s
Netbox, parallel: 3.1s (Not changed/not measurable, probably due to other overheads)

This is the patch with the smallest impact (<5%, it's more a micro optimization that slightly improves the code), but it shows where the next hotspot is: regex._compile. 40% is used for regex compilation (Even if there is a cache). That will be addressed in the next (and final) patch.