### PR TITLE
perf: simple skip for unformatted blocks

### DIFF
--- a/djlint/helpers.py
+++ b/djlint/helpers.py
@@ -306,8 +306,10 @@ def inside_ignored_block(
 
 @cache
 def _child_of_unformatted_block(
-    html: str, /, *, unformatted_blocks: str
+    html: str, /, *, unformatted_blocks: str, unformatted_blocks_coarse: str
 ) -> tuple[tuple[int, int], ...]:
+    if not re.search(unformatted_blocks_coarse, html, flags=RE_FLAGS_IMSX):
+        return ()
     return tuple(
         x.span()
         for x in re.finditer(unformatted_blocks, html, flags=RE_FLAGS_IMSX)
@@ -320,7 +322,9 @@ def child_of_unformatted_block(
     """Do not add whitespace if the tag is in a non indent block."""
     match_start, match_end = match.span()
     for ignored_match_start, ignored_match_end in _child_of_unformatted_block(
-        html, unformatted_blocks=config.unformatted_blocks
+        html,
+        unformatted_blocks=config.unformatted_blocks,
+        unformatted_blocks_coarse=config.unformatted_blocks_coarse,
     ):
         if ignored_match_start < match_start and match_end <= ignored_match_end:
             return True

--- a/djlint/settings.py
+++ b/djlint/settings.py
@@ -847,6 +847,8 @@ class Config:
            {%-?[ ]*?raw\b(?:(?!%}).)*?-?%}.*?(?={%-?[ ]*?endraw[ ]*?-?%})
         """
 
+        self.unformatted_blocks_coarse: str = r"djlint\:\s*off"
+
         self.unformatted_blocks: str = r"""
             # html comment
             | <!--\s*djlint\:off\s*-->.(?:(?!<!--\s*djlint\:on\s*-->).)*


### PR DESCRIPTION
# Pull Request Check List (For completeness)

Resolves: No issue, since only performance improvements

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Neither are necessary, since again, only performance improvements.

# Actual Description :>

This adds a simple check for unformatted blocks (djlint:off blocks) before using the quite expensive proper ones.
As @JCWasmx86 suggested in his last PR, djlint spends a lot of time on those unformatted block checks.

I couldn't figure out a more elaborate solution without making it really complicated, but for most projects (those without lots of djlint:off blocks) this will basically yield perfect results.

As common in @JCWasmx86 PRs, I used [edx-platform repo](https://github.com/openedx/edx-platform) as a benchmark (average of 10 runs, all files in the repo):

1. Current master (1.36.0): 6.7s
2. This PR: 1.45s