### PR TITLE
fix #1052: template tag inside template tag

### DIFF
--- a/djlint/formatter/expand.py
+++ b/djlint/formatter/expand.py
@@ -112,9 +112,7 @@ def expand_html(html: str, config: Config) -> str:
 
     # break after
     return re.sub(
-        r"((?:{%|{{\#)[ ]*?(?:"
-        + config.break_template_tags
-        + ")[^}]+?[%}]})(?=[^\n])",
+        rf"((?:{{%|{{{{\#)[ ]*?(?:{config.break_template_tags})(?>{config.template_tags}|[^}}])+?[%}}]}})(?=[^\n])",
         partial(should_i_move_template_tag, "%s\n"),
         html,
         flags=RE_FLAGS_IMX,

--- a/djlint/settings.py
+++ b/djlint/settings.py
@@ -727,6 +727,10 @@ class Config:
         """
         )
 
+        self.template_tags = r"""
+            {{(?:(?!}}).)*}}|{%(?:(?!%}).)*%}
+        """
+
         self.html_tag_regex = r"""
             (</?(?:!(?!--))?) # an opening bracket (< or </ or <!), but not a comment
             ([^\s>!\[]+\b) # a tag name

--- a/djlint/settings.py
+++ b/djlint/settings.py
@@ -728,7 +728,7 @@ class Config:
         )
 
         self.template_tags = r"""
-            {{(?:(?!}}).)*}}|{%(?:(?!%}).)*%}
+        {{(?:(?!}}).)*}}|{%(?:(?!%}).)*%}
         """
 
         self.html_tag_attribute_regex = rf"""

--- a/tests/test_django/test_templatetag_ext.py
+++ b/tests/test_django/test_templatetag_ext.py
@@ -1,0 +1,33 @@
+"""Test template tag extended usage.
+
+uv run pytest tests/test_django/test_templatetag_ext.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from djlint.reformat import formatter
+from tests.conftest import config_builder, printer
+
+if TYPE_CHECKING:
+    from typing import Any
+
+test_data = [
+    pytest.param(
+        ('{% component "img" src="{% url \'my_image\' %}" %}'),
+        ('{% component "img" src="{% url \'my_image\' %}" %}\n'),
+        ({"custom_blocks": "component"}),
+        id="template_tag_inside_template_tag",
+    )
+]
+
+
+@pytest.mark.parametrize(("source", "expected", "args"), test_data)
+def test_base(source: str, expected: str, args: dict[str, Any]) -> None:
+    output = formatter(config_builder(args), source)
+
+    printer(expected, source, output)
+    assert expected == output


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1052

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
(no real need to update docs)

This is a quick fix.

Overall I think djlint should be refactored in some regards. 

Many regexes (like this one I modified) should be using existing basic regexes as building blocks more I think.
Many regexes don't respect nesting of brackets and escaping properly (again, like this one here), and do not respect the differences between what e.g. an attribute key or value. 

Both these issues rarely matter, but I could definitely construct valid django templates where they do. Not super easy to fix/refactor, so I'm currently trying to cover some ground with these smaller issues/PRs and get some tests for all of my use cases, so I'm maybe confident enough to refactor some stuff later.
