### PR TITLE
fix: django-components self closing tags indenting

### DIFF
--- a/djlint/formatter/indent.py
+++ b/djlint/formatter/indent.py
@@ -238,6 +238,11 @@ def indent_html(rawcode: str, config: Config) -> str:
                 flags=RE_FLAGS_IMX,
             )
             and not is_block_raw
+            and not re.search(
+                config.template_tags_self_closing,
+                item,
+                flags=RE_FLAGS_IMX,
+            )
         ):
             tmp = (indent * indent_level) + item + "\n"
             indent_level += 1

--- a/djlint/settings.py
+++ b/djlint/settings.py
@@ -727,6 +727,14 @@ class Config:
         """
         )
 
+        self.template_tags = r"""
+            {{(?:(?!}}).)*}}|{%(?:(?!%}).)*%}
+        """
+
+        self.template_tags_self_closing = r"""
+            {%(?:(?!%}).)*\/\s%}
+        """
+
         self.html_tag_regex = r"""
             (</?(?:!(?!--))?) # an opening bracket (< or </ or <!), but not a comment
             ([^\s>!\[]+\b) # a tag name

--- a/djlint/settings.py
+++ b/djlint/settings.py
@@ -727,10 +727,6 @@ class Config:
         """
         )
 
-        self.template_tags = r"""
-            {{(?:(?!}}).)*}}|{%(?:(?!%}).)*%}
-        """
-
         self.template_tags_self_closing = r"""
             {%(?:(?!%}).)*\/\s%}
         """

--- a/tests/test_django/test_django_components.py
+++ b/tests/test_django/test_django_components.py
@@ -1,0 +1,33 @@
+"""Test template tag special django-components syntax.
+
+uv run pytest tests/test_django/test_django_components.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from djlint.reformat import formatter
+from tests.conftest import config_builder, printer
+
+if TYPE_CHECKING:
+    from typing import Any
+
+test_data = [
+    pytest.param(
+        ('{% component "icon" name="save" /%}\nHello World\n'),
+        ('{% component "icon" name="save" / %}\nHello World\n'),
+        ({"custom_blocks": "component"}),
+        id="self_closing_tag",
+    )
+]
+
+
+@pytest.mark.parametrize(("source", "expected", "args"), test_data)
+def test_base(source: str, expected: str, args: dict[str, Any]) -> None:
+    output = formatter(config_builder(args), source)
+
+    printer(expected, source, output)
+    assert expected == output


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1054

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
(no docs needed imo)

This adds a check for django-components self-closing template tags, such that they don't get indented.

I do not think a special settings and/or handling is currently necessary, since this is a non-breaking change for all other use-cases, but I would say if there are more of these special cases for django-components or other packages, I will refactor this into a having a config or something.