### PR TITLE
Fix: indentation for handlebars unless

### DIFF
--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -603,6 +603,7 @@ class Config:
         self.indent_template_tags: str = (
             (rf"(?!{self.ignore_blocks})" if self.ignore_blocks else "")
             + r""" (?:if
+                | unless
                 | ifchanged
                 | for
                 | asyncEach
@@ -788,6 +789,7 @@ class Config:
             (rf"(?!{self.ignore_blocks})" if self.ignore_blocks else "")
             + r"""
               (?:if
+            | unless
             | for
             | asyncEach
             | asyncAll
@@ -822,6 +824,7 @@ class Config:
             (rf"(?!{self.ignore_blocks})" if self.ignore_blocks else "")
             + r"""
               (?:if
+            | unless
             | endif
             | for
             | endfor
@@ -1027,6 +1030,7 @@ class Config:
         self.optional_single_line_template_tags: str = r"""
               if
             | for
+            | unless
             | block
             | with
             | asyncEach

--- a/tests/test_handlebars/test_unless.py
+++ b/tests/test_handlebars/test_unless.py
@@ -1,0 +1,50 @@
+"""Test handlebars each tag.
+
+uv run pytest tests/test_handlebars/test_each.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from djlint.reformat import formatter
+from tests.conftest import printer
+
+if TYPE_CHECKING:
+    from djlint.settings import Config
+
+test_data = [
+    pytest.param(
+        (
+            "<html lang='en'>    <head>        <meta charset='UTF-8' />        <meta name='viewport' content='width=device-width, initial-scale=1' />        <title></title>        <link href='css/style.css' rel='stylesheet' />    </head>    <body>        {{#unless}}        <div>            <p></p>        </div>    {{/unless}}</body></html>"
+        ),
+        (
+            "<html lang='en'>\n"
+            "    <head>\n"
+            "        <meta charset='UTF-8' />\n"
+            "        <meta name='viewport' content='width=device-width, initial-scale=1' />\n"
+            "        <title></title>\n"
+            "        <link href='css/style.css' rel='stylesheet' />\n"
+            "    </head>\n"
+            "    <body>\n"
+            "        {{#unless}}\n"
+            "            <div>\n"
+            "                <p></p>\n"
+            "            </div>\n"
+            "        {{/unless}}\n"
+            "    </body>\n"
+            "</html>\n"
+        ),
+        id="unless_tag",
+    )
+]
+
+
+@pytest.mark.parametrize(("source", "expected"), test_data)
+def test_base(source: str, expected: str, handlebars_config: Config) -> None:
+    output = formatter(handlebars_config, source)
+
+    printer(expected, source, output)
+    assert expected == output


### PR DESCRIPTION
The unless tag `{{#unless}} {{/unless}}` was not seen as a template tag. 
I fixed it by adding it to the template tags config.

# Pull Request Check List

Resolves: #972

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

I don't think a documentation change is needed because handlebars supports unless but djlint didn't before this commit.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
