### PR TITLE
[doc] fix: Correct typo in CLI help text

### DIFF
--- a/djlint/__init__.py
+++ b/djlint/__init__.py
@@ -221,7 +221,7 @@ if TYPE_CHECKING:
 @click.option(
     "--close-void-tags",
     is_flag=True,
-    help="Add closing mark on known void tags. Ex: <img> becomse <img />",
+    help="Add closing mark on known void tags. Ex: <img> becomes <img />",
 )
 @click.option(
     "--no-line-after-yaml",

--- a/docs/src/_includes/cli.md
+++ b/docs/src/_includes/cli.md
@@ -55,7 +55,7 @@ Options:
   --indent-css INTEGER            Set CSS indent level.
   --indent-js INTEGER             Set JS indent level.
   --close-void-tags               Add closing mark on known void tags. Ex:
-                                  <img> becomse <img />
+                                  <img> becomes <img />
   --no-line-after-yaml            Do not add a blank line after yaml front
                                   matter.
   --no-function-formatting        Do not attempt to format function contents.


### PR DESCRIPTION
This pull request includes minor corrections to typos in the documentation and code comments. The changes ensure that the word "becomse" is corrected to "becomes" in both the `djlint/__init__.py` file and the CLI documentation.

Typos corrected:

* [`djlint/__init__.py`](diffhunk://#diff-97803ad82bc8d3a30af27492e3964bf85ec83ee7d0f1fda67fb8034442e8c2d2L224-R224): Fixed typo in the help message for the `--close-void-tags` option.
* [`docs/src/_includes/cli.md`](diffhunk://#diff-83d9d38adbb496c8416991649acc4556082f14eb9a544bcd15d05c7f00dc7a5cL58-R58): Corrected the same typo in the CLI documentation under the `Options:` section.

# Pull Request Check List

- ~~[ ] Added **tests** for changed code.~~ (Tho I'm a TDD myself, I don't think tests are necessary for this)
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->