### PR TITLE
fix(linter): stop D018/J018 flagging root href="/" links

### DIFF
--- a/src/djlint/rules.yaml
+++ b/src/djlint/rules.yaml
@@ -127,15 +127,15 @@
     message: (Django) Internal links should use the {% url ... %} pattern.
     flags: re.DOTALL|re.I
     patterns:
-      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:|sms:|/[\"'])[\w|/]+
-      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|/[\"'])[\w|/|\s]+
+      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|//|javascript:|on\w+:|mailto:|tel:|data:|sms:|/[\"'])[\w|/]+
+      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|//|javascript:|on\w+:|mailto:|tel:|/[\"'])[\w|/|\s]+
 - rule:
     name: J018
     message: (Jinja) Internal links should use the {{ url_for() ... }} pattern.
     flags: re.DOTALL|re.I
     patterns:
-      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:|sms:|/[\"'])[\w|/]+
-      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|/[\"'])[\w|/|\s]+
+      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|//|javascript:|on\w+:|mailto:|tel:|data:|sms:|/[\"'])[\w|/]+
+      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|//|javascript:|on\w+:|mailto:|tel:|/[\"'])[\w|/|\s]+
 - rule:
     name: H019
     message: Replace 'javascript:abc()' with on_ event and real url.

--- a/src/djlint/rules.yaml
+++ b/src/djlint/rules.yaml
@@ -127,15 +127,15 @@
     message: (Django) Internal links should use the {% url ... %} pattern.
     flags: re.DOTALL|re.I
     patterns:
-      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:|sms:)[\w|/]+
-      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:)[\w|/|\s]+
+      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:|sms:|/[\"'])[\w|/]+
+      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|/[\"'])[\w|/|\s]+
 - rule:
     name: J018
     message: (Jinja) Internal links should use the {{ url_for() ... }} pattern.
     flags: re.DOTALL|re.I
     patterns:
-      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:|sms:)[\w|/]+
-      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:)[\w|/|\s]+
+      - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:|sms:|/[\"'])[\w|/]+
+      - <form(?:(?!>|\saction=(?:\"[^\"]*\"|'[^']*')).)*?\saction=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|/[\"'])[\w|/|\s]+
 - rule:
     name: H019
     message: Replace 'javascript:abc()' with on_ event and real url.

--- a/tests/test_linter/test_django_linter.py
+++ b/tests/test_linter/test_django_linter.py
@@ -251,6 +251,14 @@ test_data = [
         id="DJ018_root",
     ),
     pytest.param(
+        (
+            '<a href="//cdn.example.com/path"></a>\n'
+            '<form action="//cdn.example.com/path"></form>'
+        ),
+        ([]),
+        id="DJ018_protocol_relative",
+    ),
+    pytest.param(
         ('<a href="data:,Hello%2C%20World%21"></a>'), ([]), id="DJ018_data"
     ),
     pytest.param(

--- a/tests/test_linter/test_django_linter.py
+++ b/tests/test_linter/test_django_linter.py
@@ -246,6 +246,11 @@ test_data = [
         id="DJ018_mailto",
     ),
     pytest.param(
+        ('<a href="/">Home</a>\n<form action="/"></form>'),
+        ([]),
+        id="DJ018_root",
+    ),
+    pytest.param(
         ('<a href="data:,Hello%2C%20World%21"></a>'), ([]), id="DJ018_data"
     ),
     pytest.param(

--- a/tests/test_linter/test_jinja_linter.py
+++ b/tests/test_linter/test_jinja_linter.py
@@ -117,6 +117,11 @@ test_data = [
         id="J018_mailto",
     ),
     pytest.param(
+        ('<a href="/">Home</a>\n<form action="/"></form>'),
+        ([]),
+        id="J018_root",
+    ),
+    pytest.param(
         ('<a href="data:,Hello%2C%20World%21"></a>'), ([]), id="J018_data"
     ),
     pytest.param(

--- a/tests/test_linter/test_jinja_linter.py
+++ b/tests/test_linter/test_jinja_linter.py
@@ -122,6 +122,14 @@ test_data = [
         id="J018_root",
     ),
     pytest.param(
+        (
+            '<a href="//cdn.example.com/path"></a>\n'
+            '<form action="//cdn.example.com/path"></form>'
+        ),
+        ([]),
+        id="J018_protocol_relative",
+    ),
+    pytest.param(
         ('<a href="data:,Hello%2C%20World%21"></a>'), ([]), id="J018_data"
     ),
     pytest.param(

--- a/tests/test_linter/test_jinja_linter.py
+++ b/tests/test_linter/test_jinja_linter.py
@@ -117,9 +117,7 @@ test_data = [
         id="J018_mailto",
     ),
     pytest.param(
-        ('<a href="/">Home</a>\n<form action="/"></form>'),
-        ([]),
-        id="J018_root",
+        ('<a href="/">Home</a>\n<form action="/"></form>'), ([]), id="J018_root"
     ),
     pytest.param(
         (


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1601

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

D018 and J018 flagged `<a href="/">` and `<form action="/">` as internal links that should use `{% url %}`/`url_for()`. A bare root `/` is the site root, not a named page, so this was a false positive. The negative lookahead now also excludes a value that is exactly `/`.
