### PR TITLE
fix: blank-line-after/before-tag ignores whitespace-control dashes ({%- -%})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Semantic Versioning](https://semver.org/)
 
+## Unreleased
+
+### Fix
+
+- Respect whitespace-control dashes when applying `blank_line_after_tag` and `blank_line_before_tag`.
+
 ## [1.39.2] - 2026-06-11
 
 v1.39.1 was not published due to mypyc compilation error.

--- a/src/djlint/formatter/condense.py
+++ b/src/djlint/formatter/condense.py
@@ -105,7 +105,7 @@ def clean_whitespace(html: str, config: Config) -> str:
     if config.blank_line_after_tag:
         for tag in config.blank_line_after_tag.split(","):
             html = re.sub(
-                rf"((?:{{%\s*?{tag.strip()}\b[^}}]+?%}}\n?)+)",
+                rf"((?:{{%-?\s*?{tag.strip()}\b[^}}]+?-?%}}\n?)+)",
                 func,
                 html,
                 flags=RE_FLAGS_IMS,
@@ -126,7 +126,7 @@ def clean_whitespace(html: str, config: Config) -> str:
     if config.blank_line_before_tag:
         for tag in config.blank_line_before_tag.split(","):
             html = re.sub(
-                rf"(?<!^\n)((?:{{%\s*?{tag.strip()}\b[^}}]+?%}}\n?)+)",
+                rf"(?<!^\n)((?:{{%-?\s*?{tag.strip()}\b[^}}]+?-?%}}\n?)+)",
                 func,
                 html,
                 flags=RE_FLAGS_IMS,
@@ -209,7 +209,7 @@ def condense_html(html: str, config: Config, source: str | None = None) -> str:
         if config.blank_line_after_tag:
             for tag in config.blank_line_after_tag.split(","):
                 if re.search(
-                    rf"((?:{{%\s*?{tag.strip()}[^}}]+?%}}\n?)+)",
+                    rf"((?:{{%-?\s*?{tag.strip()}[^}}]+?-?%}}\n?)+)",
                     html,
                     flags=RE_FLAGS_IMS,
                 ):
@@ -221,7 +221,7 @@ def condense_html(html: str, config: Config, source: str | None = None) -> str:
         if config.blank_line_before_tag:
             for tag in config.blank_line_before_tag.split(","):
                 if re.search(
-                    rf"((?:{{%\s*?{tag.strip()}[^}}]+?%}}\n?)+)",
+                    rf"((?:{{%-?\s*?{tag.strip()}[^}}]+?-?%}}\n?)+)",
                     html,
                     flags=RE_FLAGS_IMS,
                 ):

--- a/tests/test_config/test_blank_line_after_tag.py
+++ b/tests/test_config/test_blank_line_after_tag.py
@@ -135,6 +135,40 @@ test_data = [
         ({"blank_line_after_tag": "   include     ,endblock "}),
         id="test multiple",
     ),
+    pytest.param(
+        (
+            "{%- macro Foo() -%}\n"
+            "  <div>foo</div>\n"
+            "{%- endmacro -%}\n"
+            "<p>after macro</p>\n"
+        ),
+        (
+            "{%- macro Foo() -%}\n"
+            "    <div>foo</div>\n"
+            "{%- endmacro -%}\n"
+            "\n"
+            "<p>after macro</p>\n"
+        ),
+        ({"blank_line_after_tag": "endmacro"}),
+        id="nunjucks whitespace control dash - after",
+    ),
+    pytest.param(
+        (
+            "<p>before macro</p>\n"
+            "{%- macro Foo() -%}\n"
+            "  <div>foo</div>\n"
+            "{%- endmacro -%}\n"
+        ),
+        (
+            "<p>before macro</p>\n"
+            "\n"
+            "{%- macro Foo() -%}\n"
+            "    <div>foo</div>\n"
+            "{%- endmacro -%}\n"
+        ),
+        ({"blank_line_before_tag": "macro"}),
+        id="nunjucks whitespace control dash - before",
+    ),
 ]
 
 

--- a/tests/test_config/test_blank_line_after_tag.py
+++ b/tests/test_config/test_blank_line_after_tag.py
@@ -152,23 +152,6 @@ test_data = [
         ({"blank_line_after_tag": "endmacro"}),
         id="nunjucks whitespace control dash - after",
     ),
-    pytest.param(
-        (
-            "<p>before macro</p>\n"
-            "{%- macro Foo() -%}\n"
-            "  <div>foo</div>\n"
-            "{%- endmacro -%}\n"
-        ),
-        (
-            "<p>before macro</p>\n"
-            "\n"
-            "{%- macro Foo() -%}\n"
-            "    <div>foo</div>\n"
-            "{%- endmacro -%}\n"
-        ),
-        ({"blank_line_before_tag": "macro"}),
-        id="nunjucks whitespace control dash - before",
-    ),
 ]
 
 

--- a/tests/test_config/test_blank_line_before_tag.py
+++ b/tests/test_config/test_blank_line_before_tag.py
@@ -137,6 +137,23 @@ test_data = [
         ({"blank_line_before_tag": "   include     ,endblock "}),
         id="test multiple",
     ),
+    pytest.param(
+        (
+            "<p>before macro</p>\n"
+            "{%- macro Foo() -%}\n"
+            "  <div>foo</div>\n"
+            "{%- endmacro -%}\n"
+        ),
+        (
+            "<p>before macro</p>\n"
+            "\n"
+            "{%- macro Foo() -%}\n"
+            "    <div>foo</div>\n"
+            "{%- endmacro -%}\n"
+        ),
+        ({"blank_line_before_tag": "macro"}),
+        id="nunjucks whitespace control dash - before",
+    ),
 ]
 
 


### PR DESCRIPTION
# Pull Request Check List
Resolves: [#2102](https://github.com/djlint/djLint/issues/2102)

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. - N/A, no user-facing API change.

## Summary
`--blank-line-after-tag` / `blank_line_after_tag` and `--blank-line-before-tag` / `blank_line_before_tag` did not match tags using Nunjucks/Jinja whitespace-control dashes (`{%- ... -%}`).

The regex patterns in `formatter/condense.py` used `{%\s*?`, which only allows whitespace after `{%`. That skipped dashed tags, so blank lines were not inserted for those tag variants.

### Fix

- Updated all four relevant regex patterns in `formatter/condense.py` to support optional leading/trailing dash markers.
- New tag shape matched: `{{%-?\s*?...-?%}}`.
- This now covers both dashed and non-dashed forms for both blank-line-after and blank-line-before logic paths.

### Tests

- `nunjucks whitespace control dash - after` - verifies `blank_line_after_tag=endmacro` inserts a blank line after `{%- endmacro -%}`.
- `nunjucks whitespace control dash - before` - verifies `blank_line_before_tag=macro` inserts a blank line before `{%- macro ... -%}`.

Both tests fail on `master` and pass with this change.
