### PR TITLE
Treat Jinja for-else as its own branch in H025

### DIFF
--- a/src/djlint/rules/H025.py
+++ b/src/djlint/rules/H025.py
@@ -33,21 +33,22 @@ P_LIST_CHILD_MESSAGE: Final = "List tags should not be nested inside p tags."
 P_LIST_CHILD_TAGS: Final = frozenset(("ol", "ul"))
 
 _CONDITIONAL_PATTERN: Final = re.compile(
-    r"\{%[-+]?\s*(endif|elseif|elif|else|if)\b", cache_pattern=False
+    r"\{%[-+]?\s*(endfor|endif|elseif|elif|else|for|if)\b",
+    cache_pattern=False,
 )
 
 
 def _conditional_branches(html: str) -> tuple[tuple[tuple[int, int], ...], ...]:
-    """Branch spans of every complete {% if %}...{% endif %} block."""
+    """Branch spans of every complete if/endif or for/endfor block."""
     complete: list[tuple[tuple[int, int], ...]] = []
     open_blocks: list[tuple[list[tuple[int, int]], int]] = []
     for match in _CONDITIONAL_PATTERN.finditer(html):
         keyword = match.group(1)
-        if keyword == "if":
+        if keyword in {"if", "for"}:
             open_blocks.append(([], match.end()))
         elif not open_blocks:
             continue
-        elif keyword == "endif":
+        elif keyword in {"endif", "endfor"}:
             branches, start = open_blocks.pop()
             branches.append((start, match.start()))
             complete.append(tuple(branches))

--- a/tests/test_linter/test_h025.py
+++ b/tests/test_linter/test_h025.py
@@ -186,3 +186,30 @@ def test_html_inside_multiline_script_is_still_ignored(
 
     lint_printer(source, [], output[filename])
     assert not output[filename]
+
+
+def test_nested_jinja_for_else_is_not_an_orphan(jinja_config: Config) -> None:
+    # https://github.com/djlint/djLint/issues/2412
+    # A Jinja {% for %}...{% else %}...{% endfor %} else must not be treated
+    # as an if-branch, or a balanced nest flags a false H025 orphan.
+    source = (
+        "<div>\n"
+        "  {% if not thing %}\n"
+        "  <div>Message</div>\n"
+        "  {% else %}\n"
+        "  <div>\n"
+        "  {% for item in items %}\n"
+        "    <div>{{ item }}</div>\n"
+        "  {% else %}\n"
+        "    <div>No items!</div>\n"
+        "  {% endfor %}\n"
+        "  </div>\n"
+        "  {% endif %}\n"
+        "</div>\n"
+    )
+    filename = "test.html"
+
+    output = linter(jinja_config, source, filename, filename)
+
+    lint_printer(source, [], output[filename])
+    assert not output[filename]


### PR DESCRIPTION
## Summary

- H025 treated a Jinja `{% for %}…{% else %}…{% endfor %}` else as an if-branch, so a nested if + for-else on a balanced template flagged a false orphan (`H025 13:0 </div>`).
- `_conditional_branches` now nests `for`/`endfor` the same way as `if`/`endif`, so for-else is its own branch.

Reported by @joel-coffman.

Fixes #2412

## Test plan

- [x] `uv run pytest tests/test_linter/test_h025.py tests/test_linter/test_linter.py -k "H025 or h025"` — 13 passed, including the GH-2412 reporter template
- [x] Existing if/else shared-tag cases in `test_H025` still pass