### PR TITLE
fix: H037 false positive on quoted strings inside template tags in attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fix
+
+- `H037` no longer reads a quoted string inside a `{{ }}`, `{% %}`, `{# #}`, handlebars `{{{ }}}` or `{{! }}`, or mako `${ }` tag in an attribute value as an attribute, so `href="{{ url "/a/b" "/a/c" }}"` is not reported as a duplicate `a`.
+
 ## [1.45.0] - 2026-09-03
 
 ### Feature

--- a/src/djlint/rules/H037.py
+++ b/src/djlint/rules/H037.py
@@ -29,9 +29,11 @@ if TYPE_CHECKING:
 
 
 _NAME_CHAR = r"[-.:\w]"
+_TEMPLATE_TAG = r"{{.*?}}|{%.*?%}|{#.*?#}|\${[^{}]*}"
 _EVENT_PATTERN = re.compile(
-    r""""[^"]*"|'[^']*'|"""
-    r"(?P<template>{{(?:(?!}}).)*}}|{%(?:(?!%}).)*%}|{\#(?:(?!\#}).)*\#})|"
+    rf""""(?:[^"{{$]++|{_TEMPLATE_TAG}|[^"])*+"|"""
+    rf"""'(?:[^'{{$]++|{_TEMPLATE_TAG}|[^'])*+'|"""
+    rf"(?P<template>{_TEMPLATE_TAG})|"
     rf"(?P<attribute>(?<!{_NAME_CHAR}){_NAME_CHAR}+)"
     r"(?=\s*=(?:\s*)(?:\"|'|{{|{%|{\#|[\w-])|[\s/>]|$)",
     re.I | re.S,

--- a/tests/test_linter/test_h037.py
+++ b/tests/test_linter/test_h037.py
@@ -257,6 +257,41 @@ test_data = [
         ]),
         id="apline tags match",
     ),
+    pytest.param(
+        ('<a x="{% trans "a a b" %}"/>'),
+        ([]),
+        id="quoted_string_inside_block_tag_in_value",
+    ),
+    pytest.param(
+        (
+            '<a a="{{ "x x y" }}" b="{{{ "p p q" }}}" '
+            'c="{{! "m m n" }}" d="{{!-- "v v w" --}}"/>'
+        ),
+        ([]),
+        id="quoted_string_inside_expression_in_value",
+    ),
+    pytest.param(
+        ('<a x="{# "a a b" #}"/>'),
+        ([]),
+        id="quoted_string_inside_comment_in_value",
+    ),
+    pytest.param(
+        ('<a x="${"a a b"}"/>'),
+        ([]),
+        id="quoted_string_inside_mako_expression_in_value",
+    ),
+    pytest.param(
+        ('<a title="{% trans "a b" %}" title/>'),
+        ([
+            {
+                "code": "H037",
+                "line": "1:3",
+                "match": "title",
+                "message": "Duplicate attribute found.",
+            }
+        ]),
+        id="duplicate_after_quoted_string_inside_block_tag_in_value",
+    ),
 ]
 
 
@@ -282,6 +317,11 @@ golang_test_data = [
             }
         ]),
         id="comment_does_not_hide_duplicate",
+    ),
+    pytest.param(
+        ('<a x="{{Iif .X "/a/b" "/a/c"}}"/>'),
+        ([]),
+        id="quoted_paths_inside_expression_in_value",
     ),
 ]
 


### PR DESCRIPTION
Fix `H037` reporting a duplicate attribute when a quoted string inside a template tag ends an attribute value early, as in `href="{{Iif .X "/a/b" "/a/c"}}"` reporting `a`. The quoted-value scan now skips `{{ }}`, `{% %}`, `{# #}` and mako `${ }` tags, as the tokenizer already does.

- [x] Added tests for changed code.
- [x] Updated documentation for changed code.

Written with Claude Code (Fable 5.1).
