### PR TITLE
fix: H037 read unquoted values as attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fix
+
+- `H037` no longer reads an unquoted attribute value as an attribute name, so `<img width=1 height=1>` is not reported as a duplicate `1`. This started in 1.45.0.
+
 ## [1.45.2] - 2026-09-04
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fix
 
-- `H037` no longer reads an unquoted attribute value as an attribute name, so `<img width=1 height=1>` is not reported as a duplicate `1`. This started in 1.45.0.
+- `H037` no longer reads an unquoted attribute value as an attribute name, so `<img width=1 height=1>` is not reported as a duplicate `1`. This started in 1.45.0. An attribute whose unquoted value starts with a `/`, `.` or `#`, as in `href=/a`, now counts towards a duplicate.
 
 ## [1.45.2] - 2026-09-04
 

--- a/src/djlint/rules/H037.py
+++ b/src/djlint/rules/H037.py
@@ -33,6 +33,7 @@ _TEMPLATE_TAG = r"{{.*?}}|{%.*?%}|{#.*?#}|\${[^{}]*}"
 _EVENT_PATTERN = re.compile(
     rf""""(?:[^"{{$]++|{_TEMPLATE_TAG}|[^"])*+"|"""
     rf"""'(?:[^'{{$]++|{_TEMPLATE_TAG}|[^'])*+'|"""
+    r"""=\s*[\w-][^\s"'=<>`{$]*+|"""
     rf"(?P<template>{_TEMPLATE_TAG})|"
     rf"(?P<attribute>(?<!{_NAME_CHAR}){_NAME_CHAR}+)"
     r"(?=\s*=(?:\s*)(?:\"|'|{{|{%|{\#|[\w-])|[\s/>]|$)",

--- a/src/djlint/rules/H037.py
+++ b/src/djlint/rules/H037.py
@@ -33,10 +33,10 @@ _TEMPLATE_TAG = r"{{.*?}}|{%.*?%}|{#.*?#}|\${[^{}]*}"
 _EVENT_PATTERN = re.compile(
     rf""""(?:[^"{{$]++|{_TEMPLATE_TAG}|[^"])*+"|"""
     rf"""'(?:[^'{{$]++|{_TEMPLATE_TAG}|[^'])*+'|"""
-    r"""=\s*[\w-][^\s"'=<>`{$]*+|"""
+    rf"""=\s*(?:[^\s"'=<>`{{$]++|(?!{_TEMPLATE_TAG})[{{$])++|"""
     rf"(?P<template>{_TEMPLATE_TAG})|"
     rf"(?P<attribute>(?<!{_NAME_CHAR}){_NAME_CHAR}+)"
-    r"(?=\s*=(?:\s*)(?:\"|'|{{|{%|{\#|[\w-])|[\s/>]|$)",
+    r"(?=\s*=\s*[^\s=<>`]|[\s/>]|$)",
     re.I | re.S,
     cache_pattern=False,
 )

--- a/tests/test_linter/test_h037.py
+++ b/tests/test_linter/test_h037.py
@@ -307,6 +307,24 @@ test_data = [
         ]),
         id="unquoted_attributes_same",
     ),
+    pytest.param(
+        ("<a x=.foo y=.foo />"), ([]), id="punctuation_led_unquoted_values_same"
+    ),
+    pytest.param(
+        ("<a x=a$b y=a$b />"), ([]), id="literal_dollar_in_unquoted_values"
+    ),
+    pytest.param(
+        ("<a href=/a href=/b />"),
+        ([
+            {
+                "code": "H037",
+                "line": "1:3",
+                "match": "href",
+                "message": "Duplicate attribute found.",
+            }
+        ]),
+        id="duplicate_with_punctuation_led_unquoted_values",
+    ),
 ]
 
 

--- a/tests/test_linter/test_h037.py
+++ b/tests/test_linter/test_h037.py
@@ -292,6 +292,21 @@ test_data = [
         ]),
         id="duplicate_after_quoted_string_inside_block_tag_in_value",
     ),
+    pytest.param(
+        ('<img width=1 height=1 alt="" />'), ([]), id="unquoted_values_same"
+    ),
+    pytest.param(
+        ('<img width=1 width=1 alt="" />'),
+        ([
+            {
+                "code": "H037",
+                "line": "1:5",
+                "match": "width",
+                "message": "Duplicate attribute found.",
+            }
+        ]),
+        id="unquoted_attributes_same",
+    ),
 ]
 
 


### PR DESCRIPTION
Resolves #2470

Disclosure: I wrote the new tests, but I got Claude to write the updated regex as that's not my speciality.

Update: the scope has increased a bit with the CodeRabbit review feedback.

Fixes `H037` reporting a duplicate attribute when two attributes have the same unquoted value, as in `<img width=1 height=1>` reporting `1`. The scan now consumes an unquoted value the way it already consumes a quoted one, stopping before any template tag so branch tracking is unaffected. Started in 1.45.0 when bare attributes became reportable.

- [x] Added tests for changed code.
- [x] Updated documentation for changed code.

Written with Claude Code (Fable 5.1).