### PR TITLE
Remove TrackJS integration from layout

### DIFF
--- a/docs/src/_includes/layout.njk
+++ b/docs/src/_includes/layout.njk
@@ -97,14 +97,6 @@
             {% endblock body %}
         </section>
         {% include "src/_includes/foot.njk" %}
-        <script src="https://cdn.trackjs.com/agent/v3/latest/t.js"></script>
-        <script>
-          TrackJS.install({
-            token: "43e6548fbc654c889ce75878d88c9071",
-            application: "djlint"
-            // for more configuration options, see https://docs.trackjs.com
-          });
-        </script>
         <script src="{{ js.scriptsJs }}" async></script>
     </body>
 </html>


### PR DESCRIPTION
Removed TrackJS script for error tracking.

@monosans hey, this wasn't doing anything, and I'm closing the account over there. Only parsing errors in a cloudflare analytics script were reported... I killed that as well.