### PR TITLE
Remove analytics link from footer

### DIFF
--- a/docs/src/_includes/foot.njk
+++ b/docs/src/_includes/foot.njk
@@ -17,9 +17,6 @@
                 <p class="has-text-grey-dark has-text-right mt-2">
                     <small>{{ "footer_credits" | i18n | safe }}</small>
                 </p>
-                <p class="has-text-right pt-3">
-                  <a href="https://analytics.djlint.com/share/fdd3vGz2/djlint.com" target="_blank"><small>{{ "site_analytics" | i18n }}</small></a>
-                </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Removed site analytics link from footer.
@monosans I removed a broken link in the docs footer.

It was linking to an old non working umami. I also archived https://github.com/djlint/djlint-analytics/. its not used and can be deleted.

Thanks for your great work here :) 